### PR TITLE
 Update to support Spacepy 0.5.0

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -13,12 +13,10 @@ on:
     - cron: 0 0 * * * # Scheduled run every day at midnight
 jobs:
   build:
-
-    runs-on: ${{ matrix.platform }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest]
         python-version: [3.9]
 
     steps:
@@ -30,10 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install pip setuptools wheel --upgrade
-        # Install spacepy without build isolation to avoid issues with numpy
-        pip install numpy==1.26.3
-        pip install spacepy==0.4.1 --no-build-isolation
-        python -m pip install -e '.[style]'
+        python -m pip install -e .[style]
     - name: Lint with Black
       run: |
         black --check --diff swxsoc

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,9 +14,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: public.ecr.aws/w5r9l1c8/dev-swsoc-docker-lambda-base:latest
-
     strategy:
       fail-fast: false
       matrix:
@@ -24,9 +21,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
     - name: rstcheck
       run: |
-        python -m pip install -e '.[style]'
+        pip install pip setuptools wheel --upgrade
+        pip install -e .[style,docs,all]
         rstcheck -r docs 
     - name: Build docs
       run: sphinx-build docs docs/_build/html -W -b html

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,7 +13,6 @@ on:
     - cron: 0 0 * * * # Scheduled run every day at midnight
 jobs:
   build:
-
     runs-on: ${{ matrix.platform }}
     strategy:
       fail-fast: false
@@ -30,60 +29,12 @@ jobs:
     - name: Install dependencies
       run: |
         pip install pip setuptools wheel --upgrade
-        # Install spacepy without build isolation to avoid issues with numpy
-        pip install numpy==1.26.3
-        pip install spacepy==0.4.1 --no-build-isolation
         pip install -e .[test]
-      if: ${{ !(matrix.platform == 'windows-latest' && matrix.python-version == '3.11') }}
 
-    - name: Install CDF library on Ubuntu
-      run: |
-        wget https://sdc-aws-support.s3.amazonaws.com/cdf-binaries/latest.zip
-        unzip latest.zip
-        echo "CDF_LIB=cdf/lib" >> $GITHUB_ENV
-      if: ${{(matrix.platform == 'ubuntu-latest')}}
-
-    - name: Install CDF library on MacOS
-      run: |
-        wget https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/cdf39_0/macosx/CDF3_9_0-binary-signed.pkg
-        sudo installer -pkg CDF3_9_0-binary-signed.pkg -target /
-        ls -l
-        echo "CDF_LIB=cdf/lib" >> $GITHUB_ENV
-      if: ${{(matrix.platform == 'macos-latest')}}
-
-    # Set up CDF and run tests on Windows
-    - name: Install CDF on Windows
-      shell: cmd
-      run: |
-        # Download and unzip CDF
-        curl -L "https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/latest/windows/cdf3.9.0_64bit_WinZip_Installer.zip" --output cdf.zip
-        mkdir cdf_lib
-        tar -xf cdf.zip -C cdf_lib
-
-        # Set environment variables for CDF
-        set mydir=%cd%
-        set CDF_BASE=%mydir%\cdf_lib
-        set CDF_INC=%mydir%\cdf_lib\include
-        set CDF_LIB=%mydir%\cdf_lib\lib
-        set CDF_HELP=%mydir%\cdf_lib\help
-        set CDF_LEAPSECONDSTABLE=%mydir%\cdf_lib\CDFLeapSeconds.txt
-        set CLASSPATH=%mydir%\cdf_lib\CDFToolsDriver.jar;%mydir%\cdf_lib\lib\cdfjava.jar;%mydir%\cdf_lib\lib\cdfml.jar;%mydir%\cdf_lib\lib\cdfjson.jar;%mydir%\cdf_lib\lib\cdfj.jar;%mydir%\cdf_lib\lib\gson-2.8.6.jar;%mydir%\cdf_lib\lib\javax.json-1.0.4.jar;.
-        set PATH=%mydir%\cdf_lib;%mydir%\cdf_lib\bin;%PATH%
-        set TERMINFO=%mydir%\cdf_lib\lib\terminfo
-        set JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
-
-        # Run tests
-        pytest --pyargs swxsoc --cov swxsoc
-      # Skip Windows Python 3.11 tests until SpacePy is updated
-      if: ${{(matrix.platform == 'windows-latest' && matrix.python-version != '3.11')}}
-
-    - name: Run tests on Ubuntu and MacOS
+    # Run tests on Windows, Linux, and MacOS
+    - name: Run Tests
       run: pytest --pyargs swxsoc --cov swxsoc
-      env:
-        PLATFORM: ${{ matrix.platform }}
-      if: ${{ !(matrix.platform == 'windows-latest') }}
-
+    
+    # Upload coverage reports to Codecov
     - name: Upload coverage reports to Codecov with GitHub Action
       uses: codecov/codecov-action@v3
-      # Skip Windows Python 3.11 tests until SpacePy is updated
-      if: ${{ !(matrix.platform == 'windows-latest' && matrix.python-version == '3.11') }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   'astropy>=5.3.3',
   'numpy>=1.18.0',
   'sunpy>=5.0.1',
-  'spacepy>=0.4.1',
+  'spacepy>=0.5.0',
   'ndcube>=2.2.0',
   'pyyaml>=5.3.1',
 ]


### PR DESCRIPTION
Description:
SpacePy released there 0.5.0 package version which includes the CDF binaries built into the package. This PR updates the workflows and documentation building process to clean up the old process of setting up the CDF binaries beforehand.

This has been tested and works on all three of the different operating system, and tests across the core and instrument packages.

SpacePy has also included a lot of more functionality within the app, and fixed some of the versioning issues it had with numpy which required a isolated installation via pip: https://github.com/spacepy/spacepy/releases/tag/release-0.5.0