### PR TITLE
Add Support for Multiple TimeSeries

### DIFF
--- a/docs/examples/tutorial1.rst
+++ b/docs/examples/tutorial1.rst
@@ -39,7 +39,7 @@ measurement data easier when reading and writing CDF data.
     >>>
     >>> # Create support data or non-time-varying (time invariant) data
     >>> support_data = {
-    ...     "data_mask": NDData(data=np.eye(100, 100, dtype=np.uint16))
+    ...     "data_mask": NDData(data=np.eye(100, 100, dtype=np.uint16), meta={"CATDESC": "Data Mask", "VAR_TYPE": "metadata"})
     ... }
     >>> 
     >>> # Create high-dimensional data leveraging the API of NDCube
@@ -48,7 +48,7 @@ measurement data easier when reading and writing CDF data.
     ...         (
     ...             "example_spectra",
     ...             NDCube(
-    ...                 data=np.random.random(size=(4, 10)),
+    ...                 data=np.random.random(size=(1000, 10)),
     ...                 wcs=WCS(naxis=2),
     ...                 meta={"CATDESC": "Example Spectra Variable"},
     ...                 unit="eV",

--- a/swxsoc/data/config.yml
+++ b/swxsoc/data/config.yml
@@ -7,6 +7,11 @@ general:
   # note that the extra '%'s are escape characters
   time_format: "%Y-%m-%d %H:%M:%S"
 
+  # Default Key to use for Time Series time data in CDF Files
+  # Additional Time keys can be used, however the following is treated
+  # as the default and primary time variable key
+  default_timeseries_key: Epoch
+
 selected_mission: swxsoc
 
 missions_data:

--- a/swxsoc/swxdata.py
+++ b/swxsoc/swxdata.py
@@ -16,7 +16,6 @@ from astropy import units as u
 import ndcube
 from ndcube import NDCube, NDCollection
 import swxsoc
-from swxsoc.util.io import CDFHandler
 from swxsoc.util.schema import SWXSchema
 from swxsoc.util.exceptions import warn_user
 from swxsoc.util.util import VALID_DATA_LEVELS
@@ -30,15 +29,15 @@ class SWXData:
 
     Parameters
     ----------
-    timeseries :  `astropy.timeseries.TimeSeries`
-        The time series of data. Columns must be `~astropy.units.Quantity` arrays.
+    timeseries :  `Union[astropy.timeseries.TimeSeries, Dict[str, astropy.timeseries.TimeSeries]]`
+        The time-series data. This can be a single `astropy.timeseries.TimeSeries` object or a dictionary of `str` to `astropy.timeseries.TimeSeries` objects. If a dictionary, one key must be named 'epoch', the primary time axis. If non-index/time columns are included in any of the TimeSeries objects, they must be `~astropy.units.Quantity` arrays.
     support : `Optional[dict[Union[astropy.units.Quantity, astropy.nddata.NDData]]]`
         Support data arrays which do not vary with time (i.e. Non-Record-Varying data).
     spectra : `Optional[ndcube.NDCollection]`
         One or more `ndcube.NDCube` objects containing spectral or higher-dimensional
         timeseries data.
     meta : `Optional[dict]`
-        The metadata describing the time series in an ISTP-compliant format.
+        The metadata describing the data in an ISTP-compliant format.
 
     Examples
     --------
@@ -68,7 +67,7 @@ class SWXData:
     ... )
     >>> # Create a Support Structure
     >>> support_data = {
-    ...     "data_mask": NDData(data=np.eye(100, 100, dtype=np.uint16))
+    ...     "data_mask": NDData(data=np.eye(100, 100, dtype=np.uint16), meta={"CATDESC": "Data Mask", "VAR_TYPE": "metadata"})
     ... }
     >>> # Create Global Metadata Attributes
     >>> input_attrs = SWXData.global_attribute_template("eea", "l1", "1.0.0")
@@ -80,7 +79,7 @@ class SWXData:
     ValueError: If the number of columns is less than 2 or the required 'time' column is missing.
     TypeError: If any column, excluding 'time', is not an `astropy.units.Quantity` object with units.
     ValueError: If the elements of a `TimeSeries` column are multidimensional
-    TypeError: If any `supoport` data elements are not type `astropy.nddata.NDData`
+    TypeError: If any `support` data elements are not type `astropy.nddata.NDData` or `astropy.units.Quantity`.
     TypeError: If `spectra` is not an `NDCollection` object.
 
     References
@@ -95,7 +94,9 @@ class SWXData:
 
     def __init__(
         self,
-        timeseries: astropy.timeseries.TimeSeries,
+        timeseries: Union[
+            astropy.timeseries.TimeSeries, dict[str, astropy.timeseries.TimeSeries]
+        ],
         support: Optional[
             dict[Union[astropy.units.Quantity, astropy.nddata.NDData]]
         ] = None,
@@ -107,44 +108,31 @@ class SWXData:
         # ================================================
 
         # Verify TimeSeries compliance
-        if not isinstance(timeseries, TimeSeries):
-            raise TypeError(
-                "timeseries must be a `astropy.timeseries.TimeSeries` object."
-            )
-
-        if len(timeseries) == 0:
-            raise ValueError(
-                "timeseries cannot be empty, must include at least a 'time' column with valid times"
-            )
-
-        # Check individual Columns
-        for colname in timeseries.columns:
-            # Verify that all Measurements are `Quantity`
-            if colname != "time" and not isinstance(timeseries[colname], u.Quantity):
-                raise TypeError(
-                    f"Column '{colname}' must be an astropy.units.Quantity object"
-                )
-            # Verify that the Column is only a single dimension
-            if len(timeseries[colname].shape) > 1:  # If there is more than 1 Dimension
-                raise ValueError(
-                    f"Column '{colname}' must be a one-dimensional measurement. Split additional dimensions into unique measurenents."
-                )
+        if isinstance(timeseries, dict):
+            for key, value in timeseries.items():
+                self._validate_timeseries(value)
+        else:
+            self._validate_timeseries(timeseries)
 
         # Global Metadata Attributes are compiled from two places. You can pass in
         # global metadata throug the `meta` parameter or through the `TimeSeries.meta`
         # attribute.
-        _meta = {}
+        self._meta = {}
         if meta is not None and isinstance(meta, dict):
-            _meta.update(meta)
-        if timeseries.meta is not None and isinstance(timeseries.meta, dict):
-            _meta.update(timeseries.meta)
+            self._meta.update(meta)
+        if (
+            isinstance(timeseries, TimeSeries)
+            and timeseries.meta is not None
+            and isinstance(timeseries.meta, dict)
+        ):
+            self._meta.update(timeseries.meta)
 
         # Check Global Metadata Requirements - Require Descriptor, Data_level, Data_Version
-        if "Descriptor" not in _meta or _meta["Descriptor"] is None:
+        if "Descriptor" not in self._meta or self._meta["Descriptor"] is None:
             raise ValueError("'Descriptor' global meta attribute is required.")
-        if "Data_level" not in _meta or _meta["Data_level"] is None:
+        if "Data_level" not in self._meta or self._meta["Data_level"] is None:
             raise ValueError("'Data_level' global meta attribute is required.")
-        if "Data_version" not in _meta or _meta["Data_version"] is None:
+        if "Data_version" not in self._meta or self._meta["Data_version"] is None:
             raise ValueError("'Data_version' global meta attribute is required.")
 
         # Check NRV Data
@@ -167,24 +155,27 @@ class SWXData:
         #         CREATE DATA STRUCTURES
         # ================================================
 
-        # Copy the TimeSeries
-        self._timeseries = TimeSeries(timeseries, copy=True)
+        self._default_timeseries_key = swxsoc.config["general"][
+            "default_timeseries_key"
+        ]
 
-        # Add Input Metadata
-        if meta is not None and isinstance(meta, dict):
-            self._timeseries.meta.update(meta)
-
-        # Add any Metadata from the original TimeSeries
-        self._timeseries["time"].meta = OrderedDict()
-        if hasattr(timeseries["time"], "meta"):
-            self._timeseries["time"].meta.update(timeseries["time"].meta)
-
-        # Add TimeSeries Measurement Metadata
-        for col in self._timeseries.columns:
-            if col != "time":
-                self._timeseries[col].meta = self.measurement_attribute_template()
-                if hasattr(timeseries[col], "meta"):
-                    self._timeseries[col].meta.update(timeseries[col].meta)
+        if isinstance(timeseries, dict):
+            self._timeseries = {}
+            for key, value in timeseries.items():
+                # Copy the TimeSeries
+                self._timeseries[key] = TimeSeries(value, copy=True)
+                # Add any Metadata from the original TimeSeries
+                self._update_timeseries_measurement_meta(
+                    timeseries=value, epoch_key=key
+                )
+        elif isinstance(timeseries, TimeSeries):
+            self._timeseries = {
+                self._default_timeseries_key: TimeSeries(timeseries, copy=True)
+            }
+            self._update_timeseries_measurement_meta(
+                timeseries=timeseries,
+                epoch_key=self._default_timeseries_key,
+            )
 
         # Copy the Non-Record Varying Data
         if support:
@@ -194,10 +185,9 @@ class SWXData:
 
         # Add Support Metadata
         for key in self._support:
+            self._support[key].meta = self.measurement_attribute_template()
             if hasattr(support[key], "meta"):
                 self._support[key].meta.update(support[key].meta)
-            else:
-                self._support[key].meta = self.measurement_attribute_template()
 
         # Copy the High-Dimensional Spectra
         if spectra:
@@ -216,9 +206,13 @@ class SWXData:
     @property
     def timeseries(self):
         """
-        (`astropy.timeseries.TimeSeries`) A `TimeSeries` representing one or more measurements as a function of time.
+        (`astropy.timeseries.TimeSeries` or `dict`) A `TimeSeries` representing one or more measurements as a function of time.
+        If there are multiple `TimeSeries`, a dictionary is returned.
         """
-        return self._timeseries
+        if len(self._timeseries) > 1:
+            return {key: value for key, value in self._timeseries.items()}
+        else:
+            return self._timeseries[self._default_timeseries_key]
 
     @property
     def support(self):
@@ -237,27 +231,27 @@ class SWXData:
     @property
     def data(self):
         """
-        (`dict`) A `dict` containing each of `timeseries` and `support`.
+        (`dict`) A `dict` containing each of `timeseries`, `spectra` and `support`.
         """
         return {
-            "timeseries": self.timeseries,
-            "spectra": self.spectra,
-            "support": self.support,
+            "timeseries": self._timeseries,
+            "spectra": self._spectra,
+            "support": self._support,
         }
 
     @property
     def meta(self):
         """
-        (`collections.OrderedDict`) Global metadata associated with the measurement data.
+        (`dict`) Global metadata associated with the measurement data.
         """
-        return self._timeseries.meta
+        return self._meta
 
     @property
     def time(self):
         """
         (`astropy.time.Time`) The times of the measurements.
         """
-        t = Time(self._timeseries.time)
+        t = Time(self._timeseries[self._default_timeseries_key].time)
         # Set time format to enable plotting with astropy.visualisation.time_support()
         t.format = "iso"
         return t
@@ -267,7 +261,7 @@ class SWXData:
         """
         (`tuple`) The start and end times of the times.
         """
-        return (self._timeseries.time.min(), self._timeseries.time.max())
+        return (self.time.min(), self.time.max())
 
     def __repr__(self):
         """
@@ -282,12 +276,14 @@ class SWXData:
         str_repr = f"SWXData() Object:\n"
         # Global Attributes/Metedata
         str_repr += f"Global Attrs:\n"
-        for attr_name, attr_value in self._timeseries.meta.items():
+        for attr_name, attr_value in self._meta.items():
             str_repr += f"\t{attr_name}: {attr_value}\n"
         # TimeSeries Data
         str_repr += f"TimeSeries Data:\n"
-        for var_name in self._timeseries.colnames:
-            str_repr += f"\t{var_name}\n"
+        for epoch_key, ts in self._timeseries.items():
+            str_repr += f"\tTimeSeries: {epoch_key}\n"
+            for var_name in ts.colnames:
+                str_repr += f"\t\t{var_name}\n"
         # Support Data
         str_repr += f"Support Data:\n"
         for var_name in self._support.keys():
@@ -297,6 +293,34 @@ class SWXData:
         for var_name in self._spectra.keys():
             str_repr += f"\t{var_name}\n"
         return str_repr
+
+    def __getitem__(self, var_name):
+        """
+        Get the data for a specific variable.
+
+        Parameters
+        ----------
+        var_name : `str`
+            The name of the variable to retrieve.
+
+        Returns
+        -------
+        `astropy.units.Quantity` or `astropy.nddata.NDData` or `ndcube.NDCube`
+            The data for the variable.
+
+        Raises
+        ------
+        KeyError: If the variable name is not found in the `SWXData` object.
+        """
+        for epoch_key, ts in self._timeseries.items():
+            if var_name in ts.columns:
+                return ts[var_name]
+        if var_name in self.support:
+            return self.support[var_name]
+        if var_name in self.spectra:
+            return self.spectra[var_name]
+        else:
+            raise KeyError(f"Variable {var_name} not found in SWxData object.")
 
     @staticmethod
     def global_attribute_template(
@@ -366,6 +390,115 @@ class SWXData:
         """
         return SWXSchema().measurement_attribute_template()
 
+    @staticmethod
+    def get_timeseres_epoch_key(timeseries, var_data, var_meta: dict = None):
+        """
+        Function to determine the TimeSeries Epoch for a Record-Varying Variable.
+
+        Parameters
+        ----------
+        timeseries : `dict[str, astropy.timeseries.TimeSeries]`
+            A dictionary of `str` to `astropy.timeseries.TimeSeries` objects. Each `TimeSeries` object represents a different epoch.
+        var_data : `astropy.units.Quantity`
+            The variable data that we want to find the epoch for.
+        var_meta : `dict`, optional
+            The metadata associated with the variable data.
+        """
+
+        # Find the TimeSeries Epoch for this Record-Varying Variable
+        if var_meta is not None and "DEPEND_0" in var_meta:
+            epoch_key = var_meta["DEPEND_0"]
+        else:
+            # Check which epoch key to use
+            potential_epoch_keys = []
+            for key, ts in timeseries.items():
+                if hasattr(var_data, "shape"):
+                    if len(ts.time) == var_data.shape[0]:
+                        potential_epoch_keys.append(key)
+                elif hasattr(var_data, "data"):
+                    if len(ts.time) == len(var_data.data):
+                        potential_epoch_keys.append(key)
+            if len(potential_epoch_keys) == 0:
+                raise ValueError("No TimeSeries have the same length as the new data.")
+            elif len(potential_epoch_keys) > 1:
+                raise ValueError(
+                    "Multiple TimeSeries have the same length as the new data."
+                )
+            epoch_key = potential_epoch_keys[0]
+        return epoch_key
+
+    def _validate_timeseries(self, timeseries: astropy.timeseries.TimeSeries):
+        """
+        Validate a timeseries.
+
+        Parameters
+        ----------
+        timeseries : astropy.timeseries.TimeSeries
+            The timeseries to validate.
+
+        Raises
+        ------
+        TypeError
+            If the timeseries is not a `astropy.timeseries.TimeSeries` object or a dictionary of `str` to `astropy.timeseries.TimeSeries` objects.
+            If any column in the timeseries (other than 'time') is not an `astropy.units.Quantity` object.
+        ValueError
+            If the timeseries is empty.
+            If any column in the timeseries is not a one-dimensional measurement.
+        """
+        if not isinstance(timeseries, astropy.timeseries.TimeSeries):
+            raise TypeError(
+                "timeseries must be a `astropy.timeseries.TimeSeries` object or a dictionary of `str` to `astropy.timeseries.TimeSeries` objects."
+            )
+        if (
+            isinstance(timeseries, astropy.timeseries.TimeSeries)
+            and len(timeseries) == 0
+        ):
+            raise ValueError(
+                "timeseries cannot be empty, must include at least a 'time' column with valid times"
+            )
+        for colname in timeseries.columns:
+            # Verify that all Measurements are `Quantity`
+            if colname != "time" and not isinstance(timeseries[colname], u.Quantity):
+                raise TypeError(
+                    f"Column '{colname}' must be an astropy.units.Quantity object"
+                )
+            # Verify that the Column is only a single dimension
+            if len(timeseries[colname].shape) > 1:  # If there is more than 1 Dimension
+                raise ValueError(
+                    f"Column '{colname}' must be a one-dimensional measurement. Split additional dimensions into unique measurements."
+                )
+
+    def _update_timeseries_measurement_meta(
+        self, timeseries: TimeSeries, epoch_key: str
+    ):
+        """
+        Update the metadata for a specific timeseries in the collection.
+
+        This method updates the metadata for both the time attribute and the measurements
+        in the timeseries. If the time attribute or a measurement has a `meta` attribute,
+        its contents are added to the corresponding attribute in the stored timeseries.
+
+        Parameters
+        ----------
+        timeseries : `astropy.timeseries.TimeSeries`
+            The timeseries whose metadata is to be updated. This timeseries should already
+            be part of the collection.
+        epoch_key : str
+            The key identifying the timeseries in the collection.
+        """
+        # Time Attributes
+        self._timeseries[epoch_key]["time"].meta = OrderedDict()
+        if hasattr(timeseries["time"], "meta"):
+            self._timeseries[epoch_key]["time"].meta.update(timeseries["time"].meta)
+        # Measurement Attributes
+        for col in timeseries.columns:
+            if col != "time":
+                self._timeseries[epoch_key][
+                    col
+                ].meta = self.measurement_attribute_template()
+                if hasattr(timeseries[col], "meta"):
+                    self._timeseries[epoch_key][col].meta.update(timeseries[col].meta)
+
     def _derive_metadata(self):
         """
         Funtion to derive global and measurement metadata based on a SWXSchema
@@ -376,44 +509,63 @@ class SWXData:
             self._update_global_attribute(attr_name, attr_value)
 
         # Global Attributes
-        for attr_name, attr_value in self.schema.derive_global_attributes(
-            self._timeseries
-        ).items():
+        for attr_name, attr_value in self.schema.derive_global_attributes(self).items():
             self._update_global_attribute(attr_name, attr_value)
 
-        # Measurement Attributes
-        for data_structure in [self.timeseries, self.support, self.spectra]:
-            for col in data_structure.keys():
+        for epoch_key, ts in self._timeseries.items():
+            # Time Measurement Attributes
+            for col in ts.columns:
                 for attr_name, attr_value in self.schema.derive_measurement_attributes(
-                    data_structure, col
+                    self, col
                 ).items():
                     self._update_measurement_attribute(
-                        data_structure=data_structure,
+                        data_structure=ts,
                         var_name=col,
                         attr_name=attr_name,
                         attr_value=attr_value,
                     )
 
+        # Support/ Non-Record-Varying Data
+        for col in self._support:
+            for attr_name, attr_value in self.schema.derive_measurement_attributes(
+                self, col
+            ).items():
+                self._update_measurement_attribute(
+                    data_structure=self._support,
+                    var_name=col,
+                    attr_name=attr_name,
+                    attr_value=attr_value,
+                )
+
+        # Spectra/ High-Dimensional Data
+        for col in self._spectra:
+            for attr_name, attr_value in self.schema.derive_measurement_attributes(
+                self, col
+            ).items():
+                self._update_measurement_attribute(
+                    data_structure=self._spectra,
+                    var_name=col,
+                    attr_name=attr_name,
+                    attr_value=attr_value,
+                )
+
     def _update_global_attribute(self, attr_name, attr_value):
         # If the attribute is set, check if we want to overwrite it
-        if (
-            attr_name in self._timeseries.meta
-            and self._timeseries.meta[attr_name] is not None
-        ):
+        if attr_name in self._meta and self._meta[attr_name] is not None:
             # We want to overwrite if:
             #   1) The actual value is not the derived value
             #   2) The schema marks this attribute to be overwriten
             if (
-                self._timeseries.meta[attr_name] != attr_value
+                self._meta[attr_name] != attr_value
                 and self.schema.global_attribute_schema[attr_name]["overwrite"]
             ):
                 warn_user(
-                    f"Overriding Global Attribute {attr_name} : {self._timeseries.meta[attr_name]} -> {attr_value}"
+                    f"Overriding Global Attribute {attr_name} : {self._meta[attr_name]} -> {attr_value}"
                 )
-                self._timeseries.meta[attr_name] = attr_value
+                self._meta[attr_name] = attr_value
         # If the attribute is not set, set it
         else:
-            self._timeseries.meta[attr_name] = attr_value
+            self._meta[attr_name] = attr_value
 
     def _update_measurement_attribute(
         self, data_structure, var_name, attr_name, attr_value
@@ -466,16 +618,46 @@ class SWXData:
                 f"Column '{measure_name}' must be a one-dimensional measurement. Split additional dimensions into unique measurenents."
             )
 
-        self._timeseries[measure_name] = data
+            # Find the TimeSeries Epoch for this Record-Varying Variable
+        epoch_key = SWXData.get_timeseres_epoch_key(self._timeseries, data, meta)
+
+        # Add the new measurement
+        self._timeseries[epoch_key][measure_name] = data
         # Add any Metadata from the original Quantity
-        self._timeseries[measure_name].meta = self.measurement_attribute_template()
+        self._timeseries[epoch_key][
+            measure_name
+        ].meta = self.measurement_attribute_template()
         if hasattr(data, "meta"):
-            self._timeseries[measure_name].meta.update(data.meta)
+            self._timeseries[epoch_key][measure_name].meta.update(data.meta)
         if meta:
-            self._timeseries[measure_name].meta.update(meta)
+            self._timeseries[epoch_key][measure_name].meta.update(meta)
 
         # Derive Metadata Attributes for the Measurement
         self._derive_metadata()
+
+    def add_timeseries(self, epoch_key: str, timeseries: TimeSeries):
+        """
+        Add a new TimeSeries object to the collection of epochs.
+
+        Parameters
+        ----------
+        epoch_key: `str`
+            The key to identify the new TimeSeries.
+        timeseries: `astropy.timeseries.TimeSeries`
+            The time-series data to add.
+        """
+        self._validate_timeseries(timeseries)
+
+        # Check the epoch is not already used
+        if epoch_key in self._timeseries:
+            raise ValueError(f"Epoch key {epoch_key} is already in use.")
+        else:
+            # Add the TimeSeries
+            self._timeseries[epoch_key] = TimeSeries(timeseries, copy=True)
+            # Updata the Metadata
+            self._update_timeseries_measurement_meta(
+                timeseries=timeseries, epoch_key=epoch_key
+            )
 
     def add_support(
         self,
@@ -569,13 +751,22 @@ class SWXData:
         measure_name: `str`
             Name of the variable to remove.
         """
-        if measure_name in self._timeseries.columns:
-            self._timeseries.remove_column(measure_name)
-        elif measure_name in self._support:
+        found = False
+        # Check TimeSeries
+        for epoch_key, ts in self._timeseries.items():
+            if measure_name in ts.columns:
+                self._timeseries[epoch_key].remove_column(measure_name)
+                found = True
+        # Check Support
+        if measure_name in self._support:
             self._support.pop(measure_name)
+            found = True
+        # Check Spectra
         elif measure_name in self._spectra:
             self._spectra.pop(measure_name)
-        else:
+            found = True
+        # Otherwise Raise and Error
+        if not found:
             raise ValueError(f"Data for Measurement {measure_name} not found.")
 
     def plot(self, axes=None, columns=None, subplots=True, **plot_args):
@@ -686,38 +877,27 @@ class SWXData:
             The data to be appended (rows) as a `TimeSeries` object.
         """
         # Verify TimeSeries compliance
-        if not isinstance(timeseries, TimeSeries):
-            raise TypeError("Data must be a TimeSeries object.")
-        if len(timeseries.columns) < 2:
-            raise ValueError("Data must have at least 2 columns")
-        if len(self.timeseries.columns) != len(timeseries.columns):
-            raise ValueError(
-                (
-                    f"Shape of curent TimeSeries ({len(self.timeseries.columns)}) does not match",
-                    f"shape of data to add ({len(timeseries.columns)}).",
-                )
-            )
+        self._validate_timeseries(timeseries)
 
-        # Check individual Columns
-        for colname in self.timeseries.columns:
-            if colname != "time" and not isinstance(
-                self.timeseries[colname], u.Quantity
-            ):
-                raise TypeError(
-                    f"Column '{colname}' must be an astropy.Quantity object"
-                )
+        # Check which epoch key to use
+        selected_epoch_key = SWXData.get_timeseres_epoch_key(
+            self._timeseries, timeseries.time
+        )
 
         # Save Metadata since it is not carried over with vstack
         metadata_holder = {
-            col: self.timeseries[col].meta for col in self.timeseries.columns
+            col: self._timeseries[selected_epoch_key][col].meta
+            for col in self._timeseries[selected_epoch_key].columns
         }
 
         # Vertically Stack the TimeSeries
-        self._timeseries = vstack([self._timeseries, timeseries])
+        self._timeseries[selected_epoch_key] = vstack(
+            [self._timeseries[selected_epoch_key], timeseries]
+        )
 
         # Add Metadata back to the Stacked TimeSeries
-        for col in self.timeseries.columns:
-            self.timeseries[col].meta = metadata_holder[col]
+        for col in self._timeseries[selected_epoch_key].columns:
+            self._timeseries[selected_epoch_key][col].meta = metadata_holder[col]
 
         # Re-Derive Metadata
         self._derive_metadata()
@@ -738,6 +918,8 @@ class SWXData:
         path : `str`
             A path to the saved file.
         """
+        from swxsoc.util.io import CDFHandler
+
         handler = CDFHandler()
         if not output_path:
             output_path = Path.cwd()
@@ -767,6 +949,8 @@ class SWXData:
         ValueError: If the file type is not recognized as a file type that can be loaded.
 
         """
+        from swxsoc.util.io import CDFHandler
+
         # Determine the file type
         file_extension = file_path.suffix
 
@@ -777,5 +961,5 @@ class SWXData:
             raise ValueError(f"Unsupported file type: {file_extension}")
 
         # Load data using the handler and return a SWXData object
-        timeseries, support, spectra = handler.load_data(file_path)
-        return cls(timeseries=timeseries, support=support, spectra=spectra)
+        timeseries, support, spectra, meta = handler.load_data(file_path)
+        return cls(timeseries=timeseries, support=support, spectra=spectra, meta=meta)

--- a/swxsoc/util/io.py
+++ b/swxsoc/util/io.py
@@ -10,6 +10,8 @@ from astropy.wcs import WCS
 import astropy.units as u
 from ndcube import NDCollection
 from ndcube import NDCube
+import swxsoc
+from swxsoc.swxdata import SWXData
 from swxsoc.util.exceptions import warn_user
 from swxsoc.util.schema import SWXSchema
 
@@ -26,7 +28,7 @@ class SWXIOHandler(ABC):
     """
 
     @abstractmethod
-    def load_data(self, file_path: Path) -> Tuple[TimeSeries, dict]:
+    def load_data(self, file_path: Path) -> Tuple[dict, dict, NDCollection, dict]:
         """
         Load data from a file.
 
@@ -37,12 +39,14 @@ class SWXIOHandler(ABC):
 
         Returns
         -------
-        data : `~astropy.time.TimeSeries`
+        timeseries : `dict[~astropy.time.TimeSeries]`
             An instance of `TimeSeries` containing the loaded data.
         support : `dict[astropy.nddata.NDData]`
             Non-record-varying data contained in the file
         spectra : `ndcube.NDCollection`
             Spectral or High-dimensional measurements in the loaded data.
+        meta: `dict`
+            Global metadata attributes.
         """
         pass
 
@@ -79,7 +83,7 @@ class CDFHandler(SWXIOHandler):
         # CDF Schema
         self.schema = SWXSchema()
 
-    def load_data(self, file_path: Path) -> Tuple[TimeSeries, dict]:
+    def load_data(self, file_path: Path) -> Tuple[dict, dict, NDCollection, dict]:
         """
         Load heliophysics data from a CDF file.
 
@@ -90,20 +94,25 @@ class CDFHandler(SWXIOHandler):
 
         Returns
         -------
-        data : `~astropy.time.TimeSeries`
+        timeseries : `dict[~astropy.time.TimeSeries]`
             An instance of `TimeSeries` containing the loaded data.
         support : `dict[astropy.nddata.NDData]`
             Non-record-varying data contained in the file
         spectra : `ndcube.NDCollection`
             Spectral or High-dimensional measurements in the loaded data.
+        meta: `dict`
+            Global metadata attributes.
         """
         from spacepy.pycdf import CDF
 
         if not file_path.exists():
             raise FileNotFoundError(f"CDF Could not be loaded from path: {file_path}")
 
-        # Create a new TimeSeries
-        ts = TimeSeries()
+        # Create a Struct for Global Metadata
+        meta = {}
+        # Create a struct for storing TimeSeries
+        timeseries = {}
+        default_timeseries_key = swxsoc.config["general"]["default_timeseries_key"]
         # Create a Data Structure for Non-record Varying Data
         support = {}
         # Intermediate Type
@@ -123,23 +132,35 @@ class CDFHandler(SWXIOHandler):
                 else:
                     # gAttr is a single value
                     input_global_attrs[attr_name] = input_file.attrs[attr_name][0]
-            ts.meta.update(input_global_attrs)
+            meta.update(input_global_attrs)
 
-            # First Variable we need to add is time/Epoch
-            if "Epoch" in input_file:
-                time_data = Time(input_file["Epoch"][:].copy())
-                time_attrs = self._load_metadata_attributes(input_file["Epoch"])
+            # First Variables we need to add are time/Epoch
+            epoch_variables = [
+                var_name for var_name in input_file.keys() if "Epoch" in var_name
+            ]
+            # Make sure the Default "Epoch" is present in the CDF
+            if default_timeseries_key not in epoch_variables:
+                warn_user(
+                    f"Epoch Variable {default_timeseries_key} not found in CDF file: {file_path}"
+                )
+            # Loop for each Epoch Variable
+            for epoch_var in epoch_variables:
+                time_data = Time(input_file[epoch_var][:].copy())
+                time_attrs = self._load_metadata_attributes(input_file[epoch_var])
+                # Create a new TimeSeries
+                timeseries[epoch_var] = TimeSeries()
                 # Create the Time object
-                ts["time"] = time_data
+                timeseries[epoch_var]["time"] = time_data
                 # Create the Metadata
-                ts["time"].meta = OrderedDict()
-                ts["time"].meta.update(time_attrs)
+                timeseries[epoch_var]["time"].meta = OrderedDict()
+                timeseries[epoch_var]["time"].meta.update(time_attrs)
 
             # Get all the Keys for Measurement Variable Data
             # These are Keys where the underlying object is a `dict` that contains
             # additional data, and is not the `EPOCH` variable
-            variable_keys = filter(lambda key: key != "Epoch", list(input_file.keys()))
-            # Add Variable Attributtes from the CDF file to TimeSeries
+            variable_keys = [
+                var_name for var_name in input_file.keys() if "Epoch" not in var_name
+            ]
             for var_name in variable_keys:
                 # Extract the Variable's Metadata
                 var_attrs = self._load_metadata_attributes(input_file[var_name])
@@ -147,45 +168,26 @@ class CDFHandler(SWXIOHandler):
                 # Extract the Variable's Data
                 var_data = input_file[var_name][...]
                 if input_file[var_name].rv():
-                    # See if it is record-varying data with Units
+
+                    # Find the TimeSeries Epoch for this Record-Varying Variable
+                    epoch_key = SWXData.get_timeseres_epoch_key(
+                        timeseries, var_data, var_attrs
+                    )
+                    ts = timeseries[epoch_key]
+
+                    # See if it is record-varying data with UNITS
                     if "UNITS" in var_attrs and len(var_data) == len(ts["time"]):
                         # Check if the variable is multi-dimensional
                         if len(var_data.shape) > 1:
-                            try:
-                                # Create an NDCube Object for the data
-                                self._load_spectra_variable(
-                                    spectra, var_name, var_data, var_attrs, ts.time
-                                )
-                            except ValueError:
-                                warn_user(
-                                    f"Cannot create NDCube for Spectra {var_name} with UNITS {var_attrs['UNITS']}. Creating Quantity with UNITS 'dimensionless_unscaled'."
-                                )
-                                # Swap Units
-                                var_attrs["UNITS_DESC"] = var_attrs["UNITS"]
-                                var_attrs["UNITS"] = (
-                                    u.dimensionless_unscaled.to_string()
-                                )
-                                self._load_spectra_variable(
-                                    spectra, var_name, var_data, var_attrs, ts.time
-                                )
+                            # Load as Spectra Data
+                            self._load_spectra_variable(
+                                spectra, var_name, var_data, var_attrs, ts.time
+                            )
                         else:
                             # Load as Record-Varying `data`
-                            try:
-                                self._load_timeseries_variable(
-                                    ts, var_name, var_data, var_attrs
-                                )
-                            except ValueError:
-                                warn_user(
-                                    f"Cannot create Quantity for Variable {var_name} with UNITS {var_attrs['UNITS']}. Creating Quantity with UNITS 'dimensionless_unscaled'."
-                                )
-                                # Swap Units
-                                var_attrs["UNITS_DESC"] = var_attrs["UNITS"]
-                                var_attrs["UNITS"] = (
-                                    u.dimensionless_unscaled.to_string()
-                                )
-                                self._load_timeseries_variable(
-                                    ts, var_name, var_data, var_attrs
-                                )
+                            self._load_timeseries_variable(
+                                ts, var_name, var_data, var_attrs
+                            )
                     else:
                         # Load as `support`
                         self._load_support_variable(
@@ -196,15 +198,10 @@ class CDFHandler(SWXIOHandler):
                     self._load_support_variable(support, var_name, var_data, var_attrs)
 
         # Create a NDCollection
-        if len(spectra) > 0:
-            # Implement assertion that all spectra are aligned along time-varying dimension
-            aligned_axes = tuple(0 for _ in spectra)
-            spectra = NDCollection(spectra, aligned_axes=aligned_axes)
-        else:
-            spectra = NDCollection(spectra)
+        spectra = NDCollection(spectra)
 
-        # Return the given TimeSeries, NRV Data
-        return ts, support, spectra
+        # Return the given TimeSeries, NRV Data, Spectra Data, Global Metadata
+        return timeseries, support, spectra, meta
 
     def _load_metadata_attributes(self, var_data):
         var_attrs = {}
@@ -217,13 +214,26 @@ class CDFHandler(SWXIOHandler):
                 var_attrs[attr_name] = var_data.attrs[attr_name]
         return var_attrs
 
-    def _load_timeseries_variable(self, ts, var_name, var_data, var_attrs):
-        # Create the Quantity object
-        var_data = u.Quantity(value=var_data, unit=var_attrs["UNITS"], copy=False)
-        ts[var_name] = var_data
-        # Create the Metadata
-        ts[var_name].meta = OrderedDict()
-        ts[var_name].meta.update(var_attrs)
+    def _load_timeseries_variable(self, timeseries, var_name, var_data, var_attrs):
+        def _load_data(timeseries, var_name, var_data, var_attrs):
+            # Create a Quantity object for the variable
+            timeseries[var_name] = u.Quantity(
+                value=var_data, unit=var_attrs["UNITS"], copy=False
+            )
+            # Create the Metadata
+            timeseries[var_name].meta = OrderedDict()
+            timeseries[var_name].meta.update(var_attrs)
+
+        try:
+            _load_data(timeseries, var_name, var_data, var_attrs)
+        except ValueError:
+            warn_user(
+                f"Cannot create Quantity for Variable {var_name} with UNITS {var_attrs['UNITS']}. Creating Quantity with UNITS 'dimensionless_unscaled'."
+            )
+            # Swap UNITS
+            var_attrs["UNITS_DESC"] = var_attrs["UNITS"]
+            var_attrs["UNITS"] = u.dimensionless_unscaled.to_string()
+            _load_data(timeseries, var_name, var_data, var_attrs)
 
     def _load_support_variable(self, support, var_name, var_data, var_attrs):
         # Create a NDData entry for the variable
@@ -300,14 +310,27 @@ class CDFHandler(SWXIOHandler):
         return wcs
 
     def _load_spectra_variable(self, spectra, var_name, var_data, var_attrs, time):
-        # Create a World Cordinate System for the Tensor
-        var_wcs = self._get_world_coords(var_data, var_attrs, time)
-        # Create a Cube
-        var_cube = NDCube(
-            data=var_data, wcs=var_wcs, meta=var_attrs, unit=var_attrs["UNITS"]
-        )
-        # Add to Spectra
-        spectra.append((var_name, var_cube))
+        def _load_data(spectra, var_name, var_data, var_attrs, time):
+            # Create a World Cordinate System for the Tensor
+            var_wcs = self._get_world_coords(var_data, var_attrs, time)
+            # Create a Cube
+            var_cube = NDCube(
+                data=var_data, wcs=var_wcs, meta=var_attrs, unit=var_attrs["UNITS"]
+            )
+            # Add to Spectra
+            spectra.append((var_name, var_cube))
+
+        try:
+            # Create an NDCube Object for the data
+            _load_data(spectra, var_name, var_data, var_attrs, time)
+        except ValueError:
+            warn_user(
+                f"Cannot create NDCube for Spectra {var_name} with UNITS {var_attrs['UNITS']}. Creating Quantity with UNITS 'dimensionless_unscaled'."
+            )
+            # Swap UNITS
+            var_attrs["UNITS_DESC"] = var_attrs["UNITS"]
+            var_attrs["UNITS"] = u.dimensionless_unscaled.to_string()
+            _load_data(spectra, var_name, var_data, var_attrs, time)
 
     def save_data(self, data, file_path: Path):
         """
@@ -350,19 +373,32 @@ class CDFHandler(SWXIOHandler):
                 cdf_file.attrs[attr_name] = attr_value
 
     def _convert_variables_to_cdf(self, data, cdf_file):
-        # Loop through Scalar TimeSeries Variables
-        for var_name in data.timeseries.colnames:
-            var_data = data.timeseries[var_name]
-            if var_name == "time":
-                # Add 'time' in the TimeSeries as 'Epoch' within the CDF
-                cdf_file["Epoch"] = var_data.to_datetime()
-                # Add the Variable Attributes
-                self._convert_variable_attributes_to_cdf("Epoch", var_data, cdf_file)
-            else:
-                # Add the Variable to the CDF File
-                cdf_file[var_name] = var_data.value
-                # Add the Variable Attributes
-                self._convert_variable_attributes_to_cdf(var_name, var_data, cdf_file)
+
+        # Make sure the Default "Epoch" is present in the CDF
+        default_timeseries_key = swxsoc.config["general"]["default_timeseries_key"]
+        if default_timeseries_key not in data.data["timeseries"]:
+            warn_user(
+                f"Epoch Variable {default_timeseries_key} not found in CDF file: {cdf_file}"
+            )
+
+        for epoch_key, ts in data.data["timeseries"].items():
+            # Loop through Scalar TimeSeries Variables
+            for var_name in ts.colnames:
+                var_data = ts[var_name]
+                if var_name == "time":
+                    # Add 'time' in the TimeSeries as 'Epoch' within the CDF
+                    cdf_file[epoch_key] = var_data.to_datetime()
+                    # Add the Variable Attributes
+                    self._convert_variable_attributes_to_cdf(
+                        epoch_key, var_data, cdf_file
+                    )
+                else:
+                    # Add the Variable to the CDF File
+                    cdf_file[var_name] = var_data.value
+                    # Add the Variable Attributes
+                    self._convert_variable_attributes_to_cdf(
+                        var_name, var_data, cdf_file
+                    )
 
         # Loop through Non-Record-Varying Data
         for var_name, var_data in data.support.items():

--- a/swxsoc/util/tests/test_io.py
+++ b/swxsoc/util/tests/test_io.py
@@ -15,6 +15,7 @@ from astropy.wcs import WCS
 from ndcube import NDCube, NDCollection
 from spacepy.pycdf import CDFError, CDF
 from swxsoc.swxdata import SWXData
+from swxsoc.util import const
 
 
 def get_test_sw_data():
@@ -53,7 +54,11 @@ def get_test_sw_data():
     )
 
     # Support Data / Non-Time Varying Data
-    support = {"support_counts": NDData(data=[1])}
+    support = {
+        "support_counts": NDData(
+            data=[1], meta={"CATDESC": "variable counts", "VAR_TYPE": "support_data"}
+        )
+    }
 
     # Spectra Data
     spectra = NDCollection(
@@ -119,11 +124,15 @@ def test_cdf_nrv_support_data():
         # Load the JSON file as JSON
         with CDF(str(test_file_output_path), readonly=False) as cdf_file:
             # Add Non-Record-Varying Variable
-            cdf_file["Test_NRV_Var"] = [1, 2, 3]
+            cdf_file.new(
+                name="Test_NRV_Var", data=[1, 2, 3], type=const.CDF_INT4, recVary=False
+            )
+            cdf_file["Test_NRV_Var"].meta["VAR_TYPE"] = "support_data"
 
             # Add Support Data Variable
             cdf_file["Test_Support_Var"] = np.arange(10)
             cdf_file["Test_Support_Var"].meta["UNITS"] = "counts"
+            cdf_file["Test_Support_Var"].meta["VAR_TYPE"] = "support_data"
 
         # Make sure we can load the modified JSON
         td_loaded = SWXData.load(test_file_output_path)

--- a/swxsoc/util/tests/test_schema.py
+++ b/swxsoc/util/tests/test_schema.py
@@ -127,7 +127,7 @@ def test_global_attributes():
 
     # Create SWXData
     td = SWXData(timeseries=ts, meta=template)
-    assert isinstance(td.meta, OrderedDict)
+    assert isinstance(td.meta, dict)
 
 
 def test_check_well_formed():


### PR DESCRIPTION
This PR relaxes the assumption that there can only be one Epoch variable within a SWxSOC data container object and SWxSOC CDF file. This is achieved through enabling the `timeseries` class member to be a `dict[string, astropy.TimeSeries]` where the key is the name of the intended epoch variable, and the value is the Time Series of measurements associated with that epoch variable.

**Changes in SWxData**

- Update functions to handle `timeseries` as single item or dict as needed
- remove global meta from the main `timeseries` to create a unique `self._meta` structure to handle global metadata.

**Changes in Schema**

- Updates `_get_depend()` to dynamically identify the correct Epoch for the given measurement

**Changes in IO**

- Update `CDFHandler` IO to load and save CDF files with multiple Epoch variables and time scales.

**This PR is based on https://github.com/HERMES-SOC/hermes_core/pull/114**
