### PR TITLE
Add `record_dimension_timestream` Functionality

### DIFF
--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -12,6 +12,7 @@ For more details checkout the :ref:`reference`.
 
    Brief Tour <tour>
    reading_writing_data
+   recording_to_timestream
    schema_information_guide
    cdf_format_guide
    customization

--- a/docs/user-guide/recording_to_timestream.rst
+++ b/docs/user-guide/recording_to_timestream.rst
@@ -1,63 +1,35 @@
 .. _recording_to_timestream:
 
-=============================================
-Record Measures and Dimensions in Timestream
-=============================================
+=====================================
+Record Measurements to AWS Timestream
+=====================================
 
-This module provides functionality to record measures with dimensions in an AWS Timestream database. You can log various metrics and associate them with specific instruments and dimensions for effective data analysis.
+This module provides functionality to record measurements to an `AWS Timestream <https://docs.aws.amazon.com/timestream/>`_ database which can then be visualized in a Grafana Dashboard.
+Measurements can be anything such as housekeeping data or science data as long as each measurement is associated with a time stamp.
 
-Prerequisites
-=============
-Before using the `~swxsoc.util.util.record_dimension_timestream` function, ensure that the following prerequisites are met:
+.. warning::
+    This functionality requires AWS credentials with permission to write to the AWS timestream database.
+    If this functionality is called by the swxsox cloud pipeline then those credentials are already available.
 
-- You have access to an AWS account with Timestream enabled and configured.
-
-.. note::
-    If you are using the `~swxsoc.util.util.record_dimension_timestream` function within the cloud processing pipeline, you do not need to worry about this prerequisite.
-
-
-Using the `record_dimension_timestream` Function
-==================================================
-To record dimensions in Timestream, you need to call the `~swxsoc.util.util.record_dimension_timestream` function with the appropriate parameters. Below is an example of how to use this function.
+Writing data
+============
+The primary interface to write data into the Timestream datase is the `~swxsoc.util.util.record_timeseries` function.
+Its primary input is a `~astropy.timeseries.TimeSeries` object.
+The column names will be used as the label for the measurement.
 
 Example Usage
 -------------
 .. code-block::
 
-    from swxsoc.util.util import record_dimension_timestream
+    from astropy import units as u
+    from astropy.timeseries import TimeSeries
+    ts = TimeSeries(time_start='2016-03-22T12:30:31',
+                    time_delta=3 * u.s,
+                    n_samples=5)
+    ts['volt1'] = [1., 4., 5., 6., 4.] * u.volt
 
-    # First measurement: Temperature Reading
-    instrument_name = "eea"
-    dimensions = [
-        {"Name": "Location", "Value": "Mars"},
-        {"Name": "SensorType", "Value": "Temperature"},
-        {"Name": "Unit", "Value": "Celsius"},
-    ]
-    measure_name = "temperature_reading"
-    measure_value = 25.2
-    measure_value_type = "DOUBLE";
+    from swxsoc.util.util import record_timeseries
 
-    # Record the temperature reading
-    record_dimension_timestream(
-        dimensions=dimensions,
-        instrument_name=instrument_name,
-        measure_name=measure_name,
-        measure_value=measure_value,
-        measure_value_type=measure_value_type,
-    )
+    record_timeseries(ts, instrument_name='test')
 
-    >>> INFO: Using timestamp: 1727258906620 [swxsoc.util.util]
-    >>> INFO: Successfully wrote record {'Time': '1727258906620', 'Dimensions': [{'Name': 'Location', 'Value': 'Mars'}, {'Name': 'SensorType', 'Value': 'Temperature'}, {'Name': 'Unit', 'Value': 'Celsius'}, {'Name': 'InstrumentName', 'Value': 'eea'}], 'MeasureName': 'temperature_reading', 'MeasureValue': '25.2', 'MeasureValueType': 'DOUBLE'} to Timestream: dev-sdc_aws_logs/dev-measures_table [swxsoc.util.util]
-
-
-
-Parameters
-==========
-The `~swxsoc.util.util.record_dimension_timestream` function accepts the following parameters:
-
-- **dimensions** (list): A list of dimensions to record. Each dimension should be a dictionary with `Name` and `Value` keys.
-- **instrument_name** (str, optional): The name of the instrument being logged. Defaults to `None`.
-- **measure_name** (str): The name of the measure being recorded. Defaults to `"timestamp"`.
-- **measure_value** (any, optional): The value of the measure being recorded. If not provided, defaults to the current UTC timestamp.
-- **measure_value_type** (str): The type of the measure value (e.g., `"DOUBLE"`, `"BIGINT"`). Defaults to `"DOUBLE"`.
-- **timestamp** (str, optional): The timestamp for the record in milliseconds. Defaults to the current time in milliseconds if not provided.
+Note that if duplicate measurements are sent then the last writer wins.

--- a/docs/user-guide/recording_to_timestream.rst
+++ b/docs/user-guide/recording_to_timestream.rst
@@ -22,7 +22,7 @@ To record dimensions in Timestream, you need to call the `~swxsoc.util.util.reco
 
 Example Usage
 -------------
-.. code-block:: python
+.. code-block::
 
     from swxsoc.util.util import record_dimension_timestream
 

--- a/docs/user-guide/recording_to_timestream.rst
+++ b/docs/user-guide/recording_to_timestream.rst
@@ -7,17 +7,18 @@ Record Measures and Dimensions in Timestream
 This module provides functionality to record measures with dimensions in an AWS Timestream database. You can log various metrics and associate them with specific instruments and dimensions for effective data analysis.
 
 Prerequisites
-============
-Before using the `record_dimension_timestream` function, ensure that the following prerequisites are met:
+=============
+Before using the `~swxsoc.util.util.record_dimension_timestream` function, ensure that the following prerequisites are met:
 
 - You have access to an AWS account with Timestream enabled and configured.
+
 .. note::
-    If you are using the `record_dimension_timestream` function within the cloud processing pipeline, you do not need to worry about this prerequisite.
+    If you are using the `~swxsoc.util.util.record_dimension_timestream` function within the cloud processing pipeline, you do not need to worry about this prerequisite.
 
 
 Using the `record_dimension_timestream` Function
 ==================================================
-To record dimensions in Timestream, you need to call the `record_dimension_timestream` function with the appropriate parameters. Below is an example of how to use this function.
+To record dimensions in Timestream, you need to call the `~swxsoc.util.util.record_dimension_timestream` function with the appropriate parameters. Below is an example of how to use this function.
 
 Example Usage
 -------------
@@ -52,7 +53,7 @@ Example Usage
 
 Parameters
 ==========
-The `record_dimension_timestream` function accepts the following parameters:
+The `~swxsoc.util.util.record_dimension_timestream` function accepts the following parameters:
 
 - **dimensions** (list): A list of dimensions to record. Each dimension should be a dictionary with `Name` and `Value` keys.
 - **instrument_name** (str, optional): The name of the instrument being logged. Defaults to `None`.
@@ -60,4 +61,3 @@ The `record_dimension_timestream` function accepts the following parameters:
 - **measure_value** (any, optional): The value of the measure being recorded. If not provided, defaults to the current UTC timestamp.
 - **measure_value_type** (str): The type of the measure value (e.g., `"DOUBLE"`, `"BIGINT"`). Defaults to `"DOUBLE"`.
 - **timestamp** (str, optional): The timestamp for the record in milliseconds. Defaults to the current time in milliseconds if not provided.
-

--- a/docs/user-guide/recording_to_timestream.rst
+++ b/docs/user-guide/recording_to_timestream.rst
@@ -1,0 +1,63 @@
+.. _recording_to_timestream:
+
+=============================================
+Record Measures and Dimensions in Timestream
+=============================================
+
+This module provides functionality to record measures with dimensions in an AWS Timestream database. You can log various metrics and associate them with specific instruments and dimensions for effective data analysis.
+
+Prerequisites
+============
+Before using the `record_dimension_timestream` function, ensure that the following prerequisites are met:
+
+- You have access to an AWS account with Timestream enabled and configured.
+.. note::
+    If you are using the `record_dimension_timestream` function within the cloud processing pipeline, you do not need to worry about this prerequisite.
+
+
+Using the `record_dimension_timestream` Function
+==================================================
+To record dimensions in Timestream, you need to call the `record_dimension_timestream` function with the appropriate parameters. Below is an example of how to use this function.
+
+Example Usage
+-------------
+.. code-block:: python
+
+    from swxsoc.util.util import record_dimension_timestream
+
+    # First measurement: Temperature Reading
+    instrument_name = "eea"
+    dimensions = [
+        {"Name": "Location", "Value": "Mars"},
+        {"Name": "SensorType", "Value": "Temperature"},
+        {"Name": "Unit", "Value": "Celsius"},
+    ]
+    measure_name = "temperature_reading"
+    measure_value = 25.2
+    measure_value_type = "DOUBLE";
+
+    # Record the temperature reading
+    record_dimension_timestream(
+        dimensions=dimensions,
+        instrument_name=instrument_name,
+        measure_name=measure_name,
+        measure_value=measure_value,
+        measure_value_type=measure_value_type,
+    )
+
+    >>> INFO: Using timestamp: 1727258906620 [swxsoc.util.util]
+    >>> INFO: Successfully wrote record {'Time': '1727258906620', 'Dimensions': [{'Name': 'Location', 'Value': 'Mars'}, {'Name': 'SensorType', 'Value': 'Temperature'}, {'Name': 'Unit', 'Value': 'Celsius'}, {'Name': 'InstrumentName', 'Value': 'eea'}], 'MeasureName': 'temperature_reading', 'MeasureValue': '25.2', 'MeasureValueType': 'DOUBLE'} to Timestream: dev-sdc_aws_logs/dev-measures_table [swxsoc.util.util]
+
+
+
+Parameters
+==========
+The `record_dimension_timestream` function accepts the following parameters:
+
+- **dimensions** (list): A list of dimensions to record. Each dimension should be a dictionary with `Name` and `Value` keys.
+- **instrument_name** (str, optional): The name of the instrument being logged. Defaults to `None`.
+- **measure_name** (str): The name of the measure being recorded. Defaults to `"timestamp"`.
+- **measure_value** (any, optional): The value of the measure being recorded. If not provided, defaults to the current UTC timestamp.
+- **measure_value_type** (str): The type of the measure value (e.g., `"DOUBLE"`, `"BIGINT"`). Defaults to `"DOUBLE"`.
+- **timestamp** (str, optional): The timestamp for the record in milliseconds. Defaults to the current time in milliseconds if not provided.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,10 @@ dependencies = [
   'astropy>=5.3.3',
   'numpy>=1.18.0',
   'sunpy>=5.0.1',
-  'spacepy>=0.4.1',
+  'spacepy>=0.6.0',
   'ndcube>=2.2.0',
   'pyyaml>=5.3.1',
+  'boto3==1.35.26'
 ]
 
 [project.optional-dependencies]
@@ -43,7 +44,8 @@ dev = [
   'pytest-cov==4.1.0',
   'black==24.1.1',
   'flake8==7.0.0',
-  'coverage[toml]==7.4.1'
+  'coverage[toml]==7.4.1',
+  'moto[all]==5.0.15'
 ]
 
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,8 @@ test = [
   'pytest==8.0.0',
   'pytest-astropy==0.11.0',
   'pytest-cov==4.1.0',
-  'coverage[toml]==7.4.1'
+  'coverage[toml]==7.4.1',
+  'moto[all]==5.0.15'
 ]
 
 style = [

--- a/swxsoc/data/config.yml
+++ b/swxsoc/data/config.yml
@@ -91,4 +91,3 @@ logger:
 
   # Format for log file entries
   log_file_format: "%(asctime)s, %(origin)s, %(levelname)s, %(message)s"
-  

--- a/swxsoc/data/config.yml
+++ b/swxsoc/data/config.yml
@@ -7,6 +7,11 @@ general:
   # note that the extra '%'s are escape characters
   time_format: "%Y-%m-%d %H:%M:%S"
 
+  # Default Key to use for Time Series time data in CDF Files
+  # Additional Time keys can be used, however the following is treated
+  # as the default and primary time variable key
+  default_timeseries_key: Epoch
+
 selected_mission: swxsoc
 
 missions_data:
@@ -52,14 +57,14 @@ missions_data:
   padre:
     file_extension: fits
     instruments:
-      - name: eea
-        shortname: eea
-        fullname: Electron Electrostatic Analyzer
-        targetname: EEA
-      - name: nemisis
-        shortname: nem
-        fullname: Noise Eliminating Magnetometer Instrument in a Small Integrated System
-        targetname: NEM
+      - name: meddea
+        shortname: meddea
+        fullname: MeDDEA
+        targetname: MEDDEA
+      - name: sharp
+        shortname: sharp
+        fullname:  Solar HARd X-ray Polarimeter
+        targetname: SHARP
 
 logger:
   # Threshold for the logging messages. Logging messages that are less severe

--- a/swxsoc/data/config.yml
+++ b/swxsoc/data/config.yml
@@ -91,3 +91,4 @@ logger:
 
   # Format for log file entries
   log_file_format: "%(asctime)s, %(origin)s, %(levelname)s, %(message)s"
+  

--- a/swxsoc/util/tests/test_timestream.py
+++ b/swxsoc/util/tests/test_timestream.py
@@ -1,0 +1,200 @@
+"""Tests util.py that interact with timestream"""
+
+import boto3
+from moto import mock_aws
+from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
+from moto.timestreamwrite.models import timestreamwrite_backends
+
+from astropy import units as u
+from astropy.timeseries import TimeSeries
+
+from swxsoc.util import util
+
+# Create a timestream database with boto3
+client = boto3.client("timestream-write", region_name="us-east-1")
+database_name = "dev-swxsoc_sdc_aws_logs"
+table_name = "dev-swxsoc_measures_table"
+client.create_database(DatabaseName=database_name)
+
+# Create a table in the database
+client.create_table(
+    DatabaseName=database_name,
+    TableName=table_name,
+    RetentionProperties={
+        "MemoryStoreRetentionPeriodInHours": 24,
+        "MagneticStoreRetentionPeriodInDays": 7,
+    },
+)
+
+
+@mock_aws
+def test_record_timeseries_quantity_1col():
+
+    ts = TimeSeries(time_start="2016-03-22T12:30:31", time_delta=3 * u.s, n_samples=5)
+    ts["temp4"] = [1.0, 4.0, 5.0, 6.0, 4.0] * u.deg_C
+    util.record_timeseries(ts, instrument_name="test")
+
+    database_name = "dev-swxsoc_sdc_aws_logs"
+    table_name = "dev-swxsoc_measures_table"
+
+    backend = timestreamwrite_backends[ACCOUNT_ID]["us-east-1"]
+    records = backend.databases[database_name].tables[table_name].records
+
+    assert len(records) == len(ts["temp4"])
+    # TODO assert measureName == temp4_deg_C
+    # TODO assert measureValues == ts["temp4"].value
+    # TODO assert len(measureValues) == 1  only one column of data
+    # TODO assert timestamp[0] == 2016-03-22T12:30:31.000
+
+
+@mock_aws
+def test_record_timeseries_quantity_multicol():
+    """Test with more than one column and a column without a quantity."""
+    ts = TimeSeries(time_start="2016-03-22T12:30:31", time_delta=3 * u.s, n_samples=5)
+    ts["temp4"] = [1.0, 4.0, 5.0, 6.0, 4.0] * u.deg_C
+    ts["rail5v"] = [5.1, 5.2, 4.9, 4.8, 5.0] * u.volt
+    ts["status"] = [0, 1, 1, 1, 2]
+    util.record_timeseries(ts, instrument_name="test")
+
+    database_name = "dev-swxsoc_sdc_aws_logs"
+    table_name = "dev-swxsoc_measures_table"
+
+    backend = timestreamwrite_backends[ACCOUNT_ID]["us-east-1"]
+    records = backend.databases[database_name].tables[table_name].records
+
+    assert len(records) == len(ts["temp4"]) * 3
+    # TODO assert measureName0 == temp4_deg_C
+    # TODO assert measureName1 == rail5v_volt
+    # TODO assert measureName2 == status
+    # TODO assert measureValues0 == ts["temp4"].value
+    # TODO assert len(measureValues) == 3  
+    # TODO assert timestamp[0] == 2016-03-22T12:30:31.000
+
+
+@mock_aws
+def test_record_dimension_timestream():
+    # Create a timestream database with boto3
+    client = boto3.client("timestream-write", region_name="us-east-1")
+    database_name = "dev-swxsoc_sdc_aws_logs"
+    table_name = "dev-swxsoc_measures_table"
+    client.create_database(DatabaseName=database_name)
+
+    # Create a table in the database
+    client.create_table(
+        DatabaseName=database_name,
+        TableName=table_name,
+        RetentionProperties={
+            "MemoryStoreRetentionPeriodInHours": 24,
+            "MagneticStoreRetentionPeriodInDays": 7,
+        },
+    )
+
+    instrument_name = "eea"
+    dimensions = [
+        {"Name": "Location", "Value": "Mars"},
+        {"Name": "SensorType", "Value": "Temperature"},
+        {"Name": "Unit", "Value": "Celsius"},
+    ]
+    measure_name = "temperature_reading"
+    measure_value = 25.2
+    measure_value_type = "DOUBLE"
+
+    # Call the function to record dimensions in Timestream
+    util._record_dimension_timestream(
+        dimensions=dimensions,
+        instrument_name=instrument_name,
+        measure_name=measure_name,
+        measure_value=measure_value,
+        measure_value_type=measure_value_type,
+    )
+
+    instrument_name = "spani"
+    dimensions = [
+        {"Name": "Location", "Value": "Earth"},
+        {"Name": "Activity", "Value": "Running"},
+        {"Name": "Unit", "Value": "Seconds"},
+    ]
+
+    # Timestamp in milliseconds
+    timestamp = "1628460000000"
+
+    # Call the function to record the time as a measure in Timestream
+    util._record_dimension_timestream(
+        dimensions=dimensions,
+        instrument_name=instrument_name,
+        timestamp=timestamp,
+    )
+
+    backend = timestreamwrite_backends[ACCOUNT_ID]["us-east-1"]
+    records = backend.databases[database_name].tables[table_name].records
+
+    assert len(records) == 2
+
+
+@mock_aws
+def test_invalid_record_dimension_timestream():
+    # Create a timestream database with boto3
+    client = boto3.client("timestream-write", region_name="us-east-1")
+    database_name = "dev-swxsoc_sdc_aws_logs"
+    table_name = "dev-swxsoc_measures_table"
+    client.create_database(DatabaseName=database_name)
+
+    # Create a table in the database
+    client.create_table(
+        DatabaseName=database_name,
+        TableName=table_name,
+        RetentionProperties={
+            "MemoryStoreRetentionPeriodInHours": 24,
+            "MagneticStoreRetentionPeriodInDays": 7,
+        },
+    )
+
+    instrument_name = "invalid_instrument"
+    dimensions = [
+        {"Name": "Location", "Value": "Mars"},
+        {"Name": "SensorType", "Value": "Temperature"},
+        {"Name": "Unit", "Value": "Celsius"},
+    ]
+
+    # Call the function to record dimensions in Timestream
+    util._record_dimension_timestream(
+        dimensions=dimensions,
+    )
+
+    backend = timestreamwrite_backends[ACCOUNT_ID]["us-east-1"]
+    record = backend.databases[database_name].tables[table_name].records[0]
+
+    record_dimensions = record["Dimensions"]
+
+    # Check if InstrumentName is in the record dimensions
+    assert "InstrumentName" not in record_dimensions
+
+
+@mock_aws
+def test_invalid_instrument_record_dimension_timestream():
+    # Create a timestream database with boto3
+    client = boto3.client("timestream-write", region_name="us-east-1")
+    database_name = "dev-swxsoc_sdc_aws_logs"
+    table_name = "dev-swxsoc_measures_table"
+    client.create_database(DatabaseName=database_name)
+
+    # Create a table in the database
+    client.create_table(
+        DatabaseName=database_name,
+        TableName=table_name,
+        RetentionProperties={
+            "MemoryStoreRetentionPeriodInHours": 24,
+            "MagneticStoreRetentionPeriodInDays": 7,
+        },
+    )
+
+    dimensions = "invalid"
+
+    # Call the function to record dimensions in Timestream
+    util._record_dimension_timestream(dimensions=dimensions)
+
+    backend = timestreamwrite_backends[ACCOUNT_ID]["us-east-1"]
+    records = backend.databases[database_name].tables[table_name].records
+
+    # Assert that no records were created
+    assert len(records) == 0

--- a/swxsoc/util/tests/test_timestream.py
+++ b/swxsoc/util/tests/test_timestream.py
@@ -1,36 +1,60 @@
 """Tests util.py that interact with timestream"""
 
+import os
 import boto3
 from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 from moto.timestreamwrite.models import timestreamwrite_backends
+import pytest
 
 from astropy import units as u
 from astropy.timeseries import TimeSeries
 
+
 from swxsoc.util import util
 
-# Create a timestream database with boto3
-client = boto3.client("timestream-write", region_name="us-east-1")
-database_name = "dev-swxsoc_sdc_aws_logs"
-table_name = "dev-swxsoc_measures_table"
-client.create_database(DatabaseName=database_name)
 
-# Create a table in the database
-client.create_table(
-    DatabaseName=database_name,
-    TableName=table_name,
-    RetentionProperties={
-        "MemoryStoreRetentionPeriodInHours": 24,
-        "MagneticStoreRetentionPeriodInDays": 7,
-    },
-)
+@pytest.fixture(scope="function")
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
 
 
-@mock_aws
-def test_record_timeseries_quantity_1col():
+@pytest.fixture(scope="function")
+def mocked_timestream(aws_credentials):
+    """
+    Return a mocked S3 client
+    """
+    with mock_aws():
+        """Fixture to mock Timestream database and table."""
+        client = boto3.client("timestream-write", region_name="us-east-1")
+        database_name = "dev-swxsoc_sdc_aws_logs"
+        table_name = "dev-swxsoc_measures_table"
+        client.create_database(DatabaseName=database_name)
 
-    ts = TimeSeries(time_start="2016-03-22T12:30:31", time_delta=3 * u.s, n_samples=5)
+        client.create_table(
+            DatabaseName=database_name,
+            TableName=table_name,
+            RetentionProperties={
+                "MemoryStoreRetentionPeriodInHours": 24,
+                "MagneticStoreRetentionPeriodInDays": 7,
+            },
+        )
+        yield client
+
+
+def test_record_timeseries_quantity_1col(mocked_timestream):
+    timeseries_name = "test_measurements"
+    ts = TimeSeries(
+        time_start="2016-03-22T12:30:31",
+        time_delta=3 * u.s,
+        n_samples=5,
+        meta={"name": timeseries_name},
+    )
     ts["temp4"] = [1.0, 4.0, 5.0, 6.0, 4.0] * u.deg_C
     util.record_timeseries(ts, instrument_name="test")
 
@@ -40,21 +64,36 @@ def test_record_timeseries_quantity_1col():
     backend = timestreamwrite_backends[ACCOUNT_ID]["us-east-1"]
     records = backend.databases[database_name].tables[table_name].records
 
+    # Assert that there should be 5 records, one for each timestamp
     assert len(records) == len(ts["temp4"])
-    # TODO assert measureName == temp4_deg_C
-    # TODO assert measureValues == ts["temp4"].value
-    # TODO assert len(measureValues) == 1  only one column of data
-    # TODO assert timestamp[0] == 2016-03-22T12:30:31.000
+
+    for i, record in enumerate(records):
+        # Assert the time is correct
+        time = str(int(ts.time[i].to_datetime().timestamp() * 1000))
+        assert record["Time"] == time
+        assert record["MeasureName"] == timeseries_name
+        # Check the MeasureValues
+        measure_values = record["MeasureValues"]
+        assert len(measure_values) == 1  # Only one column of data
+
+        # Assert the measure name, value, and type
+        temp4_measure = next(
+            (mv for mv in measure_values if mv["Name"] == "temp4_deg_C"), None
+        )
+        assert temp4_measure is not None, "temp4_deg_C not found in MeasureValues"
+        assert temp4_measure["Value"] == str(
+            ts["temp4"].value[i]
+        ), "MeasureValue does not match"
+        assert temp4_measure["Type"] == "DOUBLE", "MeasureValueType does not match"
 
 
-@mock_aws
-def test_record_timeseries_quantity_multicol():
-    """Test with more than one column and a column without a quantity."""
+def test_record_timeseries_quantity_multicol(mocked_timestream):
+    timeseries_name = "test_measurements"
     ts = TimeSeries(time_start="2016-03-22T12:30:31", time_delta=3 * u.s, n_samples=5)
     ts["temp4"] = [1.0, 4.0, 5.0, 6.0, 4.0] * u.deg_C
     ts["rail5v"] = [5.1, 5.2, 4.9, 4.8, 5.0] * u.volt
     ts["status"] = [0, 1, 1, 1, 2]
-    util.record_timeseries(ts, instrument_name="test")
+    util.record_timeseries(ts, ts_name=timeseries_name, instrument_name="test")
 
     database_name = "dev-swxsoc_sdc_aws_logs"
     table_name = "dev-swxsoc_measures_table"
@@ -62,33 +101,55 @@ def test_record_timeseries_quantity_multicol():
     backend = timestreamwrite_backends[ACCOUNT_ID]["us-east-1"]
     records = backend.databases[database_name].tables[table_name].records
 
-    assert len(records) == len(ts["temp4"]) * 3
-    # TODO assert measureName0 == temp4_deg_C
-    # TODO assert measureName1 == rail5v_volt
-    # TODO assert measureName2 == status
-    # TODO assert measureValues0 == ts["temp4"].value
-    # TODO assert len(measureValues) == 3  
-    # TODO assert timestamp[0] == 2016-03-22T12:30:31.000
+    # There should be 5 records, one for each timestamp
+    assert len(records) == len(ts["temp4"])
+
+    for i, record in enumerate(records):
+        # Assert the time is correct
+        time = str(int(ts.time[i].to_datetime().timestamp() * 1000))
+        assert record["Time"] == time
+
+        # Check the MeasureValues
+        measure_values = record["MeasureValues"]
+        assert len(measure_values) == 3  # We expect 3 columns of data
+
+        # Assert for each measure
+        temp4_measure = next(
+            (mv for mv in measure_values if mv["Name"] == "temp4_deg_C"), None
+        )
+        rail5v_measure = next(
+            (mv for mv in measure_values if mv["Name"] == "rail5v_V"), None
+        )
+        status_measure = next(
+            (mv for mv in measure_values if mv["Name"] == "status"), None
+        )
+
+        assert temp4_measure is not None, "temp4_deg_C not found in MeasureValues"
+        assert temp4_measure["Value"] == str(
+            ts["temp4"].value[i]
+        ), "temp4 MeasureValue does not match"
+        assert (
+            temp4_measure["Type"] == "DOUBLE"
+        ), "temp4 MeasureValueType does not match"
+
+        assert rail5v_measure is not None, "rail5v_V not found in MeasureValues"
+        assert rail5v_measure["Value"] == str(
+            ts["rail5v"].value[i]
+        ), "rail5v MeasureValue does not match"
+        assert (
+            rail5v_measure["Type"] == "DOUBLE"
+        ), "rail5v MeasureValueType does not match"
+
+        assert status_measure is not None, "status not found in MeasureValues"
+        assert status_measure["Value"] == str(
+            ts["status"].value[i]
+        ), "status MeasureValue does not match"
+        assert (
+            status_measure["Type"] == "VARCHAR"
+        ), "status MeasureValueType does not match"
 
 
-@mock_aws
-def test_record_dimension_timestream():
-    # Create a timestream database with boto3
-    client = boto3.client("timestream-write", region_name="us-east-1")
-    database_name = "dev-swxsoc_sdc_aws_logs"
-    table_name = "dev-swxsoc_measures_table"
-    client.create_database(DatabaseName=database_name)
-
-    # Create a table in the database
-    client.create_table(
-        DatabaseName=database_name,
-        TableName=table_name,
-        RetentionProperties={
-            "MemoryStoreRetentionPeriodInHours": 24,
-            "MagneticStoreRetentionPeriodInDays": 7,
-        },
-    )
-
+def test_record_dimension_timestream(mocked_timestream):
     instrument_name = "eea"
     dimensions = [
         {"Name": "Location", "Value": "Mars"},
@@ -99,7 +160,6 @@ def test_record_dimension_timestream():
     measure_value = 25.2
     measure_value_type = "DOUBLE"
 
-    # Call the function to record dimensions in Timestream
     util._record_dimension_timestream(
         dimensions=dimensions,
         instrument_name=instrument_name,
@@ -108,47 +168,17 @@ def test_record_dimension_timestream():
         measure_value_type=measure_value_type,
     )
 
-    instrument_name = "spani"
-    dimensions = [
-        {"Name": "Location", "Value": "Earth"},
-        {"Name": "Activity", "Value": "Running"},
-        {"Name": "Unit", "Value": "Seconds"},
-    ]
-
-    # Timestamp in milliseconds
-    timestamp = "1628460000000"
-
-    # Call the function to record the time as a measure in Timestream
-    util._record_dimension_timestream(
-        dimensions=dimensions,
-        instrument_name=instrument_name,
-        timestamp=timestamp,
-    )
-
     backend = timestreamwrite_backends[ACCOUNT_ID]["us-east-1"]
-    records = backend.databases[database_name].tables[table_name].records
-
-    assert len(records) == 2
-
-
-@mock_aws
-def test_invalid_record_dimension_timestream():
-    # Create a timestream database with boto3
-    client = boto3.client("timestream-write", region_name="us-east-1")
-    database_name = "dev-swxsoc_sdc_aws_logs"
-    table_name = "dev-swxsoc_measures_table"
-    client.create_database(DatabaseName=database_name)
-
-    # Create a table in the database
-    client.create_table(
-        DatabaseName=database_name,
-        TableName=table_name,
-        RetentionProperties={
-            "MemoryStoreRetentionPeriodInHours": 24,
-            "MagneticStoreRetentionPeriodInDays": 7,
-        },
+    records = (
+        backend.databases["dev-swxsoc_sdc_aws_logs"]
+        .tables["dev-swxsoc_measures_table"]
+        .records
     )
 
+    assert len(records) == 1
+
+
+def test_invalid_record_dimension_timestream(mocked_timestream):
     instrument_name = "invalid_instrument"
     dimensions = [
         {"Name": "Location", "Value": "Mars"},
@@ -156,45 +186,32 @@ def test_invalid_record_dimension_timestream():
         {"Name": "Unit", "Value": "Celsius"},
     ]
 
-    # Call the function to record dimensions in Timestream
     util._record_dimension_timestream(
         dimensions=dimensions,
     )
 
     backend = timestreamwrite_backends[ACCOUNT_ID]["us-east-1"]
-    record = backend.databases[database_name].tables[table_name].records[0]
+    record = (
+        backend.databases["dev-swxsoc_sdc_aws_logs"]
+        .tables["dev-swxsoc_measures_table"]
+        .records[0]
+    )
 
     record_dimensions = record["Dimensions"]
 
-    # Check if InstrumentName is in the record dimensions
     assert "InstrumentName" not in record_dimensions
 
 
-@mock_aws
-def test_invalid_instrument_record_dimension_timestream():
-    # Create a timestream database with boto3
-    client = boto3.client("timestream-write", region_name="us-east-1")
-    database_name = "dev-swxsoc_sdc_aws_logs"
-    table_name = "dev-swxsoc_measures_table"
-    client.create_database(DatabaseName=database_name)
-
-    # Create a table in the database
-    client.create_table(
-        DatabaseName=database_name,
-        TableName=table_name,
-        RetentionProperties={
-            "MemoryStoreRetentionPeriodInHours": 24,
-            "MagneticStoreRetentionPeriodInDays": 7,
-        },
-    )
-
+def test_invalid_instrument_record_dimension_timestream(mocked_timestream):
     dimensions = "invalid"
 
-    # Call the function to record dimensions in Timestream
     util._record_dimension_timestream(dimensions=dimensions)
 
     backend = timestreamwrite_backends[ACCOUNT_ID]["us-east-1"]
-    records = backend.databases[database_name].tables[table_name].records
+    records = (
+        backend.databases["dev-swxsoc_sdc_aws_logs"]
+        .tables["dev-swxsoc_measures_table"]
+        .records
+    )
 
-    # Assert that no records were created
     assert len(records) == 0

--- a/swxsoc/util/tests/test_util.py
+++ b/swxsoc/util/tests/test_util.py
@@ -4,6 +4,11 @@ import os
 import pytest
 import yaml
 from pathlib import Path
+import boto3
+from moto import mock_aws
+from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
+from moto.timestreamwrite.models import timestreamwrite_backends
+
 
 from astropy.time import Time
 import swxsoc
@@ -417,3 +422,132 @@ def test_create_configdir_configured(instrument, time, level, version, result):
     del os.environ["SWXSOC_CONFIGDIR"]
     swxsoc._reconfigure()
 # fmt: on
+
+
+@mock_aws
+def test_record_dimension_timestream():
+    # Create a timestream database with boto3
+    client = boto3.client("timestream-write", region_name="us-east-1")
+    database_name = "dev-swxsoc_sdc_aws_logs"
+    table_name = "dev-swxsoc_measures_table"
+    client.create_database(DatabaseName=database_name)
+
+    # Create a table in the database
+    client.create_table(
+        DatabaseName=database_name,
+        TableName=table_name,
+        RetentionProperties={
+            "MemoryStoreRetentionPeriodInHours": 24,
+            "MagneticStoreRetentionPeriodInDays": 7,
+        },
+    )
+
+    instrument_name = "eea"
+    dimensions = [
+        {"Name": "Location", "Value": "Mars"},
+        {"Name": "SensorType", "Value": "Temperature"},
+        {"Name": "Unit", "Value": "Celsius"},
+    ]
+    measure_name = "temperature_reading"
+    measure_value = 25.2
+    measure_value_type = "DOUBLE"
+
+    # Call the function to record dimensions in Timestream
+    util.record_dimension_timestream(
+        dimensions=dimensions,
+        instrument_name=instrument_name,
+        measure_name=measure_name,
+        measure_value=measure_value,
+        measure_value_type=measure_value_type,
+    )
+
+    instrument_name = "spani"
+    dimensions = [
+        {"Name": "Location", "Value": "Earth"},
+        {"Name": "Activity", "Value": "Running"},
+        {"Name": "Unit", "Value": "Seconds"},
+    ]
+
+    # Timestamp in milliseconds
+    timestamp = "1628460000000"
+
+    # Call the function to record the time as a measure in Timestream
+    util.record_dimension_timestream(
+        dimensions=dimensions,
+        instrument_name=instrument_name,
+        timestamp=timestamp,
+    )
+
+    backend = timestreamwrite_backends[ACCOUNT_ID]["us-east-1"]
+    records = backend.databases[database_name].tables[table_name].records
+
+    assert len(records) == 2
+
+
+@mock_aws
+def test_invalid_record_dimension_timestream():
+    # Create a timestream database with boto3
+    client = boto3.client("timestream-write", region_name="us-east-1")
+    database_name = "dev-swxsoc_sdc_aws_logs"
+    table_name = "dev-swxsoc_measures_table"
+    client.create_database(DatabaseName=database_name)
+
+    # Create a table in the database
+    client.create_table(
+        DatabaseName=database_name,
+        TableName=table_name,
+        RetentionProperties={
+            "MemoryStoreRetentionPeriodInHours": 24,
+            "MagneticStoreRetentionPeriodInDays": 7,
+        },
+    )
+
+    instrument_name = "invalid_instrument"
+    dimensions = [
+        {"Name": "Location", "Value": "Mars"},
+        {"Name": "SensorType", "Value": "Temperature"},
+        {"Name": "Unit", "Value": "Celsius"},
+    ]
+
+    # Call the function to record dimensions in Timestream
+    util.record_dimension_timestream(
+        dimensions=dimensions,
+    )
+
+    backend = timestreamwrite_backends[ACCOUNT_ID]["us-east-1"]
+    record = backend.databases[database_name].tables[table_name].records[0]
+
+    record_dimensions = record["Dimensions"]
+
+    # Check if InstrumentName is in the record dimensions
+    assert "InstrumentName" not in record_dimensions
+
+
+@mock_aws
+def test_invalid_instrument_record_dimension_timestream():
+    # Create a timestream database with boto3
+    client = boto3.client("timestream-write", region_name="us-east-1")
+    database_name = "dev-swxsoc_sdc_aws_logs"
+    table_name = "dev-swxsoc_measures_table"
+    client.create_database(DatabaseName=database_name)
+
+    # Create a table in the database
+    client.create_table(
+        DatabaseName=database_name,
+        TableName=table_name,
+        RetentionProperties={
+            "MemoryStoreRetentionPeriodInHours": 24,
+            "MagneticStoreRetentionPeriodInDays": 7,
+        },
+    )
+
+    dimensions = "invalid"
+
+    # Call the function to record dimensions in Timestream
+    util.record_dimension_timestream(dimensions=dimensions)
+
+    backend = timestreamwrite_backends[ACCOUNT_ID]["us-east-1"]
+    records = backend.databases[database_name].tables[table_name].records
+
+    # Assert that no records were created
+    assert len(records) == 0

--- a/swxsoc/util/util.py
+++ b/swxsoc/util/util.py
@@ -12,7 +12,12 @@ import boto3
 import swxsoc
 
 
-__all__ = ["create_science_filename", "parse_science_filename", "VALID_DATA_LEVELS"]
+__all__ = [
+    "create_science_filename",
+    "parse_science_filename",
+    "record_dimension_timestream",
+    "VALID_DATA_LEVELS",
+]
 
 TIME_FORMAT_L0 = "%Y%j-%H%M%S"
 TIME_FORMAT = "%Y%m%dT%H%M%S"


### PR DESCRIPTION
### Overview
This pull request introduces the record_dimension_timestream function, which allows users to record measures and associated dimensions in an AWS Timestream database. This enhancement facilitates effective data logging and analysis by enabling the capture of various metrics tied to specific instruments and dimensions.

### Key Features
- Dimension Recording: Users can log multiple dimensions with their corresponding values, making data retrieval and analysis more contextual.
- Flexible Measurement Logging: Supports various measurement types and allows for custom measure names and values.
- Timestamp Handling: Automatically assigns timestamps to logged records, ensuring accurate tracking of when data was recorded.

### Also included in this PR:
- Tests which tests the recording with mock a mock aws account thanks to moto
- A User Guide docs page with an example on how to use it


### Example Usage:
```
    from swxsoc.util.util import record_dimension_timestream

    # First measurement: Temperature Reading
    instrument_name = "eea"
    dimensions = [
        {"Name": "Location", "Value": "Mars"},
        {"Name": "SensorType", "Value": "Temperature"},
        {"Name": "Unit", "Value": "Celsius"},
    ]
    measure_name = "temperature_reading"
    measure_value = 25.2
    measure_value_type = "DOUBLE";

    # Record the temperature reading
    record_dimension_timestream(
        dimensions=dimensions,
        instrument_name=instrument_name,
        measure_name=measure_name,
        measure_value=measure_value,
        measure_value_type=measure_value_type,
    )

    >>> INFO: Using timestamp: 1727258906620 [swxsoc.util.util]
    >>> INFO: Successfully wrote record {'Time': '1727258906620', 'Dimensions': [{'Name': 'Location', 'Value': 'Mars'}, {'Name': 'SensorType', 'Value': 'Temperature'}, {'Name': 'Unit', 'Value': 'Celsius'}, {'Name': 'InstrumentName', 'Value': 'eea'}], 'MeasureName': 'temperature_reading', 'MeasureValue': '25.2', 'MeasureValueType': 'DOUBLE'} to Timestream: dev-sdc_aws_logs/dev-measures_table [swxsoc.util.util]
```