### PR TITLE
Hotfix: Chunk timestream records if greater than 100 to avoid API Limit

### DIFF
--- a/swxsoc/util/util.py
+++ b/swxsoc/util/util.py
@@ -293,7 +293,7 @@ def record_timeseries(
         records.append(measure_record)
 
     # Process records in batches of 100 to avoid exceeding the Timestream API limit
-    batch_size = 100
+    batch_size = 99
     for start in range(0, len(records), batch_size):
         chunk = records[start : start + batch_size]
         try:
@@ -303,7 +303,7 @@ def record_timeseries(
                 Records=chunk,
             )
             swxsoc.log.info(
-                f"Successfully wrote {len(chunk)} records to Timestream: {database_name}/{table_name}, "
+                f"Successfully wrote {len(chunk)} {ts_name} records to Timestream: {database_name}/{table_name}, "
                 f"writeRecords Status: {result['ResponseMetadata']['HTTPStatusCode']}"
             )
         except timestream_client.exceptions.RejectedRecordsException as err:

--- a/swxsoc/util/util.py
+++ b/swxsoc/util/util.py
@@ -293,7 +293,7 @@ def record_timeseries(
         records.append(measure_record)
 
     # Process records in batches of 100 to avoid exceeding the Timestream API limit
-    batch_size = 99
+    batch_size = 100
     for start in range(0, len(records), batch_size):
         chunk = records[start : start + batch_size]
         try:

--- a/swxsoc/util/util.py
+++ b/swxsoc/util/util.py
@@ -295,7 +295,7 @@ def record_timeseries(
     # Process records in batches of 100 to avoid exceeding the Timestream API limit
     batch_size = 100
     for start in range(0, len(records), batch_size):
-        chunk = records[start : start + batch_size]
+        chunk = records[start : start + batch_size]  # noqa: E203
         try:
             result = timestream_client.write_records(
                 DatabaseName=database_name,


### PR DESCRIPTION
This is a hotfix to how records are pushed to Timestream via the api. There is a 100 record limit at a time when writing to timestream, this improves the record_timeseries function to add chunking to avoid this issue. 

Also included: 
- Add measure name to logging
- Removing instrument name if empty to avoid validation error for dimension