### PR TITLE
Integrating shared SAMMI schema package

### DIFF
--- a/docs/user-guide/cdf_format_guide.rst
+++ b/docs/user-guide/cdf_format_guide.rst
@@ -150,9 +150,6 @@ For each attribute the following information is provided:
 * derived: (`bool`) Whether the attibute can be derived by the `swxsoc`
   :py:class:`~swxsoc.util.schema.SWXSchema` class
 * required: (`bool`) Whether the attribute is required by ISTP standards
-* validate: (`bool`) Whether the attribute is included in the
-  :py:func:`~swxsoc.util.validation.validate` checks (Note, not all attributes that
-  are required are validated)
 * overwrite: (`bool`) Whether the :py:class:`~swxsoc.util.schema.SWXSchema`
   attribute derivations will overwrite an existing attribute value with an updated
   attribute value from the derivation process.
@@ -161,7 +158,7 @@ Note that this table is derived from :file:`swxsoc/data/swxsoc_default_global_cd
 
 .. csv-table:: Table 3-1: Required Global Attributes
    :file: ../generated/global_attributes.csv
-   :widths: 30, 70, 30, 30, 30, 30, 30
+   :widths: 30, 70, 30, 30, 30, 30
    :header-rows: 1
 
 --------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
 ]
 dependencies = [
+  'sammi @ git+https://github.com/alrobbertz/sammi@sammi_integration',
   'astropy>=5.3.3',
   'numpy>=1.18.0',
   'sunpy>=5.0.1',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
 ]
 dependencies = [
-  'sammi-cdf @ git+https://github.com/alrobbertz/sammi@fix_merge',
+  'sammi-cdf>=0.1.2',
   'astropy>=5.3.3',
   'numpy>=1.18.0',
   'sunpy>=5.0.1',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
 ]
 dependencies = [
-  'sammi @ git+https://github.com/alrobbertz/sammi@sammi_integration',
+  'sammi-cdf @ git+https://github.com/alrobbertz/sammi@fix_merge',
   'astropy>=5.3.3',
   'numpy>=1.18.0',
   'sunpy>=5.0.1',

--- a/swxsoc/data/swxsoc_default_global_cdf_attrs_schema.yaml
+++ b/swxsoc/data/swxsoc_default_global_cdf_attrs_schema.yaml
@@ -7,6 +7,18 @@ CDF_Lib_version:
   required: false
   validate: false
   overwrite: false
+DOI:
+  description: > 
+    DOI is a persistent Unique Digital Identifier with the form
+    https://doi.org/<PREFIX>/<SUFFIX> with the <PREFIX> identifying the DOI
+    registration authority and the <SUFFIX> identifying the dataset. The DOI should point to
+    a landing page for additional information about the dataset. DOIs are typically created by
+    the SPASE naming authority or archive.
+  default: null
+  derived: false
+  required: false # NOT Required in ISTP Guide (Recommended)
+  validate: true
+  overwrite: false
 Data_level:
   description: >
     This attribute is used in file name creation and records the level of processsing done
@@ -40,7 +52,7 @@ Data_type:
   default: null
   derived: true
   derivation_fn: _get_data_type
-  required: true
+  required: false # NOT Required in ISTP Guide (Derived)
   validate: true
   overwrite: true
 Data_version:
@@ -74,6 +86,15 @@ Discipline:
   required: true
   validate: true
   overwrite: false
+File_naming_convention:
+  description: >
+    If File_naming_convention was not set, it uses default setting:
+      scId_instrumentId_mode_dataLevel_optionalDataProductDescriptor_startTime_vX.Y.Z.ext
+  default: scId_instrumentId_mode_dataLevel_optionalDataProductDescriptor_startTime_vX.Y.Z.ext
+  derived: false
+  required: false
+  validate: false
+  overwrite: false
 Generation_date:
   description: >
     Date stamps the creation of the file using the syntax yyyymmdd, e.g., "
@@ -83,6 +104,59 @@ Generation_date:
   required: false # NOT Required in ISTP Guide (Recommended)
   validate: false
   overwrite: true
+HTTP_LINK:
+  description: >
+    The 'HTTP_LINK', 'LINK_TEXT', and 'LINK_TITLE' attributes store the URL with a
+    description of this dataset at the HERMES SDC. The use of HTTP_LINK attribute requires
+    the existence and equal number of corresponding LINK_TEXT and LINK_TITLE attributes. 
+    If text is not needed for these attributes, use an empty string "".
+  default: null
+  derived: false
+  required: false # NOT Required in ISTP Guide (Recommended)
+  validate: false
+  overwrite: false
+Instrument_mode:
+  description: > 
+    TBS
+  default: null
+  derived: false
+  required: false # NOT Required in ISTP Guide (Derived)
+  validate: false
+  overwrite: false
+LINK_TEXT:
+  description: >
+    The 'HTTP_LINK', 'LINK_TEXT', and 'LINK_TITLE' attributes store the URL with a
+    description of this dataset at the HERMES SDC. The use of HTTP_LINK attribute requires
+    the existence and equal number of corresponding LINK_TEXT and LINK_TITLE attributes. 
+    If text is not needed for these attributes, use an empty string "".
+  default: null
+  derived: false
+  required: false # NOT Required in ISTP Guide (Recommended)
+  validate: false
+  overwrite: false
+LINK_TITLE:
+  description: >
+    The 'HTTP_LINK', 'LINK_TEXT', and 'LINK_TITLE' attributes store the URL with a
+    description of this dataset at the HERMES SDC. The use of HTTP_LINK attribute requires
+    the existence and equal number of corresponding LINK_TEXT and LINK_TITLE attributes. 
+    If text is not needed for these attributes, use an empty string "".
+  default: null
+  derived: false
+  required: false # NOT Required in ISTP Guide (Recommended)
+  validate: false
+  overwrite: false
+MODS:
+  description: > 
+    This attribute is an SPDF standard global attribute, which is used to denote the history of
+    modifications made to the CDF data set. The MODS attribute should contain a
+    description of all significant changes to the data set, essentially capturing a log of high-
+    level release notes. This attribute can have as many entries as necessary and should be
+    updated if the Interface Number ("X") of the version number changes.
+  default: null
+  derived: false
+  required: false # NOT Required in ISTP Guide (Recommended)
+  validate: false
+  overwrite: false
 SWxSOC_version:
   description: >
     Version of `swxsoc` originally used to generate the given CDF File
@@ -190,6 +264,14 @@ Source_name:
   derived: false
   required: true
   validate: true
+  overwrite: false
+Start_time:
+  description: >
+    The start time of the contained data given in YYYYMMDD_hhmmss
+  default: null
+  derived: false
+  required: false # NOT Required in ISTP Guide (Derived)
+  validate: false
   overwrite: false
 TEXT:
   description: >

--- a/swxsoc/data/swxsoc_default_global_cdf_attrs_schema.yaml
+++ b/swxsoc/data/swxsoc_default_global_cdf_attrs_schema.yaml
@@ -1,3 +1,11 @@
+Acknowledgement:
+  description: >
+    Text string at PI disposal allowing for information on expected acknowledgment if data is citable.
+    Example: "Cite McComas et al (2016),doi:10.1007/s11214-014-0059-1"
+  default: null
+  required: false # Recommended in ISTP Guide
+  derived: false
+  overwrite: false
 CDF_Lib_version:
   description: > 
     Version of the CDF Binaries library used to generate the CDF File
@@ -5,19 +13,6 @@ CDF_Lib_version:
   derived: true
   derivation_fn: _get_cdf_lib_version
   required: false
-  validate: false
-  overwrite: false
-DOI:
-  description: > 
-    DOI is a persistent Unique Digital Identifier with the form
-    https://doi.org/<PREFIX>/<SUFFIX> with the <PREFIX> identifying the DOI
-    registration authority and the <SUFFIX> identifying the dataset. The DOI should point to
-    a landing page for additional information about the dataset. DOIs are typically created by
-    the SPASE naming authority or archive.
-  default: null
-  derived: false
-  required: false # NOT Required in ISTP Guide (Recommended)
-  validate: true
   overwrite: false
 Data_level:
   description: >
@@ -32,7 +27,6 @@ Data_level:
   default: null
   derived: false
   required: true 
-  validate: true
   overwrite: true
 Data_product_descriptor:
   description: > 
@@ -42,7 +36,6 @@ Data_product_descriptor:
   default: null
   derived: false
   required: false # NOT Required in ISTP Guide (Derived)
-  validate: false
   overwrite: true
 Data_type:
   description: >
@@ -52,8 +45,7 @@ Data_type:
   default: null
   derived: true
   derivation_fn: _get_data_type
-  required: false # NOT Required in ISTP Guide (Derived)
-  validate: true
+  required: true
   overwrite: true
 Data_version:
   description: >
@@ -61,7 +53,6 @@ Data_version:
   default: null
   derived: false
   required: true
-  validate: true
   overwrite: false
 Descriptor:
   description: >
@@ -75,7 +66,6 @@ Descriptor:
   default: null
   derived: false
   required: true
-  validate: true
   overwrite: false
 Discipline:
   description: >
@@ -84,7 +74,17 @@ Discipline:
   default: null
   derived: false
   required: true
-  validate: true
+  overwrite: false
+DOI:
+  description: > 
+    DOI is a persistent Unique Digital Identifier with the form
+    https://doi.org/<PREFIX>/<SUFFIX> with the <PREFIX> identifying the DOI
+    registration authority and the <SUFFIX> identifying the dataset. The DOI should point to
+    a landing page for additional information about the dataset. DOIs are typically created by
+    the SPASE naming authority or archive.
+  default: null
+  derived: false
+  required: false # NOT Required in ISTP Guide (Recommended)
   overwrite: false
 File_naming_convention:
   description: >
@@ -93,16 +93,21 @@ File_naming_convention:
   default: scId_instrumentId_mode_dataLevel_optionalDataProductDescriptor_startTime_vX.Y.Z.ext
   derived: false
   required: false
-  validate: false
+  overwrite: false
+Generated_by:
+  description: >
+    This attribute allows for the generating data center/group to be identified.
+  default: null
+  required: false # Recommended in ISTP Guide
+  derived: false
   overwrite: false
 Generation_date:
   description: >
     Date stamps the creation of the file using the syntax yyyymmdd, e.g., "
   default: null
+  required: false # NOT Required in ISTP Guide (Recommended)
   derived: true
   derivation_fn: _get_generation_date
-  required: false # NOT Required in ISTP Guide (Recommended)
-  validate: false
   overwrite: true
 HTTP_LINK:
   description: >
@@ -113,7 +118,6 @@ HTTP_LINK:
   default: null
   derived: false
   required: false # NOT Required in ISTP Guide (Recommended)
-  validate: false
   overwrite: false
 Instrument_mode:
   description: > 
@@ -121,50 +125,6 @@ Instrument_mode:
   default: null
   derived: false
   required: false # NOT Required in ISTP Guide (Derived)
-  validate: false
-  overwrite: false
-LINK_TEXT:
-  description: >
-    The 'HTTP_LINK', 'LINK_TEXT', and 'LINK_TITLE' attributes store the URL with a
-    description of this dataset at the HERMES SDC. The use of HTTP_LINK attribute requires
-    the existence and equal number of corresponding LINK_TEXT and LINK_TITLE attributes. 
-    If text is not needed for these attributes, use an empty string "".
-  default: null
-  derived: false
-  required: false # NOT Required in ISTP Guide (Recommended)
-  validate: false
-  overwrite: false
-LINK_TITLE:
-  description: >
-    The 'HTTP_LINK', 'LINK_TEXT', and 'LINK_TITLE' attributes store the URL with a
-    description of this dataset at the HERMES SDC. The use of HTTP_LINK attribute requires
-    the existence and equal number of corresponding LINK_TEXT and LINK_TITLE attributes. 
-    If text is not needed for these attributes, use an empty string "".
-  default: null
-  derived: false
-  required: false # NOT Required in ISTP Guide (Recommended)
-  validate: false
-  overwrite: false
-MODS:
-  description: > 
-    This attribute is an SPDF standard global attribute, which is used to denote the history of
-    modifications made to the CDF data set. The MODS attribute should contain a
-    description of all significant changes to the data set, essentially capturing a log of high-
-    level release notes. This attribute can have as many entries as necessary and should be
-    updated if the Interface Number ("X") of the version number changes.
-  default: null
-  derived: false
-  required: false # NOT Required in ISTP Guide (Recommended)
-  validate: false
-  overwrite: false
-SWxSOC_version:
-  description: >
-    Version of `swxsoc` originally used to generate the given CDF File
-  default: null
-  derived: true
-  derivation_fn: _get_swxsoc_version
-  required: false # NOT Required in ISTP Guide (Derived)
-  validate: false
   overwrite: false
 Instrument_type:
   description: > 
@@ -177,7 +137,26 @@ Instrument_type:
   default: null
   derived: false
   required: true
-  validate: true
+  overwrite: false
+LINK_TEXT:
+  description: >
+    The 'HTTP_LINK', 'LINK_TEXT', and 'LINK_TITLE' attributes store the URL with a
+    description of this dataset at the HERMES SDC. The use of HTTP_LINK attribute requires
+    the existence and equal number of corresponding LINK_TEXT and LINK_TITLE attributes. 
+    If text is not needed for these attributes, use an empty string "".
+  default: null
+  derived: false
+  required: false # NOT Required in ISTP Guide (Recommended)
+  overwrite: false
+LINK_TITLE:
+  description: >
+    The 'HTTP_LINK', 'LINK_TEXT', and 'LINK_TITLE' attributes store the URL with a
+    description of this dataset at the HERMES SDC. The use of HTTP_LINK attribute requires
+    the existence and equal number of corresponding LINK_TEXT and LINK_TITLE attributes. 
+    If text is not needed for these attributes, use an empty string "".
+  default: null
+  derived: false
+  required: false # NOT Required in ISTP Guide (Recommended)
   overwrite: false
 Logical_file_id:
   description: >
@@ -188,7 +167,6 @@ Logical_file_id:
   derived: true
   derivation_fn: _get_logical_file_id
   required: true
-  validate: true
   overwrite: true
 Logical_source:
   description: > 
@@ -203,7 +181,6 @@ Logical_source:
   derived: true
   derivation_fn: _get_logical_source
   required: true
-  validate: true
   overwrite: true
 Logical_source_description:
   description: >
@@ -214,7 +191,6 @@ Logical_source_description:
   derived: true
   derivation_fn: _get_logical_source_description
   required: true
-  validate: true
   overwrite: true
 Mission_group:
   description: >
@@ -223,7 +199,26 @@ Mission_group:
   default: null
   derived: false
   required: true
-  validate: true
+  overwrite: false
+MODS:
+  description: > 
+    This attribute is an SPDF standard global attribute, which is used to denote the history of
+    modifications made to the CDF data set. The MODS attribute should contain a
+    description of all significant changes to the data set, essentially capturing a log of high-
+    level release notes. This attribute can have as many entries as necessary and should be
+    updated if the Interface Number ("X") of the version number changes.
+  default: null
+  derived: false
+  required: false # NOT Required in ISTP Guide (Recommended)
+  overwrite: false
+Parents:
+  description: >
+    This attribute lists the parent CDF(S) for files of derived and merged data sets.
+    Subsequent entry values are used for multiple parents.
+    The syntax for a CDF parent would be e.g. "CDF>logical_file_id".
+  default: null
+  required: false # Optional in ISTP Guide
+  derived: false
   overwrite: false
 PI_affiliation:
   description: >
@@ -231,7 +226,6 @@ PI_affiliation:
   default: null
   derived: false
   required: true
-  validate: true
   overwrite: false
 PI_name:
   description: >
@@ -239,7 +233,6 @@ PI_name:
   default: null
   derived: false
   required: true
-  validate: true
   overwrite: false
 Project:
   description: >
@@ -252,7 +245,29 @@ Project:
   default: null
   derived: false
   required: true
-  validate: true
+  overwrite: false
+Rules_of_use:
+  description: >
+    Text containing information on, {\it e.g.} citability and PI access restrictions.
+    This may point to a World Wide Web page specifying the rules of use.
+  default: null
+  required: false # Recommended in ISTP Guide
+  derived: false
+  overwrite: false
+Skeleton_version:
+  description: >
+    This is a text attribute containing the skeleton file version number.
+    This is a required attribute for Cluster, but for IACG purposes it exists if experimenters want to track it.
+  default: null
+  required: false # Optional in ISTP Guide
+  derived: false
+  overwrite: false
+Software_version:
+  description: >
+    This is a required attribute for Cluster, but for IACG purposes it exists if experimenters want to track it.
+  default: null
+  required: false # Optional in ISTP Guide
+  derived: false
   overwrite: false
 Source_name:
   description: >
@@ -263,7 +278,13 @@ Source_name:
   default: null
   derived: false
   required: true
-  validate: true
+  overwrite: false
+spase_DatasetResourceID:
+  description: >
+    Unique dataset identifier assigned by SPASE, of the form spase://<NAMING_AUTHORITY>/<UNIQUE_ID>, where <UNIQUE_ID> is the ID assigned to the SPASE resource record for the dataset in the SPASE system by a SPASE <NAMING_AUTHORITY>. The SPASE resource record provides metadata about the dataset, including pointers to locations holding the data.
+  default: null
+  required: false # Recommended in ISTP Guide
+  derived: false
   overwrite: false
 Start_time:
   description: >
@@ -271,7 +292,14 @@ Start_time:
   default: null
   derived: false
   required: false # NOT Required in ISTP Guide (Derived)
-  validate: false
+  overwrite: false
+SWxSOC_version:
+  description: >
+    Version of `swxsoc` originally used to generate the given CDF File
+  default: null
+  derived: true
+  derivation_fn: _get_swxsoc_version
+  required: false # NOT Required in ISTP Guide (Derived)
   overwrite: false
 TEXT:
   description: >
@@ -285,5 +313,31 @@ TEXT:
   default: null
   derived: false
   required: true
-  validate: true
+  overwrite: false
+Time_resolution:
+  description: >
+    This attribute identifies the time resolution of the data in the CDF file.
+    The time resolution is given in seconds.
+    For example, "3 seconds" for 3-second resolution data.
+  default: null
+  required: false # Recommended in ISTP Guide
+  derived: false
+  overwrite: false
+TITLE:
+  description: >
+    This attribute is an NSSDC standard global attribute which is a title for the data set, e.g., " Geotail EPIC Key Parameters".
+  default: null
+  required: false # Optional in ISTP Guide
+  derived: false
+  overwrite: false
+Validate:
+  description: >
+    Details to be specified.
+    This attribute is written by software for automatic validation of features such as the structure of the CDF file on a simple pass/fail criterion.
+    The software will test that all expected attributes are present and, where possible, have reasonable values.
+    The syntax is likely to be of the form "test>result>where-done>date".
+    It is not the same as data validation.
+  default: null
+  required: false # Optional in ISTP Guide
+  derived: false
   overwrite: false

--- a/swxsoc/data/swxsoc_default_variable_cdf_attrs_schema.yaml
+++ b/swxsoc/data/swxsoc_default_variable_cdf_attrs_schema.yaml
@@ -100,6 +100,135 @@ attribute_key:
     overwrite: false
     valid_values: null
     alternate: null
+  CDELTi:
+    description: > 
+      This is a FITS WCS Keyword being repurposed for handling WCS transformations with 
+      high-dimensional or spectral CDF data variables. This metadata attribte should be 
+      used for the i'th dimension (1-based) and reapeated for all WCSAXES dimensions. 
+      The value field shall contain a floating point number 
+      giving the partial derivative of the coordinate specified by the CTYPEi 
+      keywords with respect to the pixel index, evaluated at the reference 
+      point CRPIXi, in units of the coordinate specified by  the CTYPEi 
+      keyword.
+    derived: true
+    derivation_fn: _get_cdelti
+    iterable: true
+    required: false   # NOT Required in CDF Guide
+    overwrite: false
+    valid_values: null
+    alternate: null
+  CNAMEi:
+    description: > 
+      This is a FITS WCS Keyword being repurposed for handling WCS transformations with 
+      high-dimensional or spectral CDF data variables. This metadata attribte should be 
+      used for the i'th dimension (1-based) and reapeated for all WCSAXES dimensions. 
+      The value shall contain a charachter string represnting the name of the i'th axis.
+      The name is used for comment/documentation purposes only and is not used as a part
+      of the i'th axis coordinate transformations.
+    derived: true
+    derivation_fn: _get_cnamei
+    iterable: true
+    required: false   # NOT Required in CDF Guide
+    overwrite: false
+    valid_values: null
+    alternate: null
+  COORDINATE_SYSTEM:
+    description: >
+      All variables for which the values are dependent on the system of coordinates are
+      strongly recommended to have this attribute. This includes both full vectors, tensors, etc.
+      or individual values, e.g. of an angle with respect to some axis. The attribute is a text
+      string which takes the form: "XXX[>optional long name]"
+    required: false
+    derived: false
+    overwrite: false
+    valid_values: null
+    alternate: null
+  CTYPEi:
+    description: > 
+      This is a FITS WCS Keyword being repurposed for handling WCS transformations with 
+      high-dimensional or spectral CDF data variables. This metadata attribte should be 
+      used for the i'th dimension (1-based) and reapeated for all WCSAXES dimensions. 
+      The value field shall contain a character string, giving
+      the name of the coordinate represented by axis i.
+    derived: true
+    derivation_fn: _get_ctypei
+    iterable: true
+    required: false   # NOT Required in CDF Guide
+    overwrite: false
+    valid_values: null
+    alternate: null
+  CUNITi:
+    description: > 
+      This is a FITS WCS Keyword being repurposed for handling WCS transformations with 
+      high-dimensional or spectral CDF data variables. This metadata attribte should be 
+      used for the i'th dimension (1-based) and reapeated for all WCSAXES dimensions. 
+      The value shall be the units along axis i, compatible with CTYPEi to be used for
+      scaling and coordinate transformations along the i'th axis. 
+    derived: true
+    derivation_fn: _get_cuniti
+    iterable: true
+    required: false   # NOT Required in CDF Guide
+    overwrite: false
+    valid_values: null
+    alternate: null
+  CRPIXi:
+    description: > 
+      This is a FITS WCS Keyword being repurposed for handling WCS transformations with 
+      high-dimensional or spectral CDF data variables. This metadata attribte should be 
+      used for the i'th dimension (1-based) and reapeated for all WCSAXES dimensions. 
+      The value field shall contain a floating point number, 
+      identifying the location of a reference point along axis i, in units of
+      the axis index.  This value is based upon a counter that runs from 1 to
+      NAXISn with an increment of 1 per pixel.  The reference point value
+      need not be that for the center of a pixel nor lie within the actual
+      data array.  Use comments to indicate the location of the index point
+      relative to the pixel.
+    derived: true
+    derivation_fn: _get_crpixi
+    iterable: true
+    required: false   # NOT Required in CDF Guide
+    overwrite: false
+    valid_values: null
+    alternate: null
+  CRVALi:
+    description: > 
+      This is a FITS WCS Keyword being repurposed for handling WCS transformations with 
+      high-dimensional or spectral CDF data variables. This metadata attribte should be 
+      used for the i'th dimension (1-based) and reapeated for all WCSAXES dimensions. 
+      The value field shall contain a floating point number,
+      giving the value of the coordinate specified by the CTYPEn keyword at
+      the reference point CRPIXi.
+    derived: true
+    derivation_fn: _get_crvali
+    iterable: true
+    required: false   # NOT Required in CDF Guide
+    overwrite: false
+    valid_values: null
+    alternate: null
+  DELTA_PLUS_VAR:
+    description: >
+      included to point to a variable (or variables) which stores the uncertainty in (or range of) the original variable's value.
+      The uncertainty (or range) is stored as a (+/-) on the value of the original variable.
+      For many variables in ISTP, the original variable will be at the center of the interval so that only one value (or one set of values) of uncertainty (or range) will need to be defined.
+      In this case, DELTA_PLUS_VAR, and DELTA_MINUS_VAR will point to the same variable.
+      The value of the attribute must be a variable in the same CDF data set.
+    required: false # Optional in ISTP Guide
+    derived: false
+    overwrite: false
+    valid_values: null
+    alternate: null
+  DELTA_MINUS_VAR:
+    description: >
+      included to point to a variable (or variables) which stores the uncertainty in (or range of) the original variable's value.
+      The uncertainty (or range) is stored as a (+/-) on the value of the original variable.
+      For many variables in ISTP, the original variable will be at the center of the interval so that only one value (or one set of values) of uncertainty (or range) will need to be defined.
+      In this case, DELTA_PLUS_VAR, and DELTA_MINUS_VAR will point to the same variable.
+      The value of the attribute must be a variable in the same CDF data set.
+    required: false # Optional in ISTP Guide
+    derived: false
+    overwrite: false
+    valid_values: null
+    alternate: null
   DEPEND_0:
     description: >
       Explicitly ties a data variable to the time variable on which it depends. All variables
@@ -123,6 +252,15 @@ attribute_key:
     overwrite: false
     valid_values: null
     alternate: null
+  DICT_KEY:
+    description: >
+      comes from a data dictionary keyword list and describes the variable to which it is attached.
+      The ISTP standard dictionary keyword list is described in ISTP Dictionary Keywords.
+    required: false # Optional in ISTP Guide
+    derived: false
+    overwrite: false
+    valid_values: null
+    alternate: null
   DISPLAY_TYPE:
     description: >
       This tells automated software, such as CDAWeb, how the data should be displayed.
@@ -136,6 +274,7 @@ attribute_key:
       spectrogram
       stack_plot
       image
+      no_plot
     alternate: null
   FIELDNAM:
     description: >
@@ -204,6 +343,148 @@ attribute_key:
     overwrite: false
     valid_values: null
     alternate: LABLAXIS
+  LIMITS_WARN_MIN:
+    description: >
+      Values which define the limits where damage is likely to occur for values outside these values (often referred to as red limits).
+      Visualization software can use these attributes for indicating limits on plots or other warnings.
+      The values data type must match the data type of the variable.
+    required: false # Optional in ISTP Guide
+    derived: false
+    overwrite: false
+    valid_values: null
+    alternate: null
+  LIMITS_WARN_MAX:
+    description: >
+      Values which define the limits where damage is likely to occur for values outside these values (often referred to as red limits).
+      Visualization software can use these attributes for indicating limits on plots or other warnings.
+      The values data type must match the data type of the variable.
+    required: false # Optional in ISTP Guide
+    derived: false
+    overwrite: false
+    valid_values: null
+    alternate: null
+  LIMITS_NOMINAL_MIN:
+    description: >
+      Values which define the range of nominal operations and where values outside the range of these values should be flagged as warnings (often referred to as yellow limits).
+      Visualization software can use these attributes for indicating limits on plots or other warnings.
+      The range of LIMITS_NOMINAL_MIN and LIMITS_NOMINAL_MAX fall within the range of LIMITS_WARN_MIN and LIMITS_WARN_MAX.
+      Yellow limits are often set a certain percentage away from the red limits to give the operator a chance to respond before the red limits are reached. The values data type must match the data type of the variable.
+    required: false # Optional in ISTP Guide
+    derived: false
+    overwrite: false
+    valid_values: null
+    alternate: null
+  LIMITS_NOMINAL_MAX:
+    description: >
+      Values which define the range of nominal operations and where values outside the range of these values should be flagged as warnings (often referred to as yellow limits).
+      Visualization software can use these attributes for indicating limits on plots or other warnings.
+      The range of LIMITS_NOMINAL_MIN and LIMITS_NOMINAL_MAX fall within the range of LIMITS_WARN_MIN and LIMITS_WARN_MAX.
+      Yellow limits are often set a certain percentage away from the red limits to give the operator a chance to respond before the red limits are reached.
+      The values data type must match the data type of the variable.
+    required: false # Optional in ISTP Guide
+    derived: false
+    overwrite: false
+    valid_values: null
+    alternate: null
+  MJDREF:
+    description: > 
+      This is a FITS WCS Keyword being repurposed for handling WCS transformations with 
+      high-dimensional or spectral CDF data variables. The value shall contain a floating
+      point number representing the reference time position of the time stamps along the 
+      0'th axis of the measurement.
+    derived: true
+    derivation_fn: _get_wcs_timeref
+    required: false   # NOT Required in CDF Guide
+    overwrite: false
+    valid_values: null
+    alternate: null
+  MONOTON:
+    description: >
+      Indicates whether the variable is monotonically increasing or monotonically decreasing.
+      Use of MONOTON is strongly recommended for the Epoch time variable, and can significantly increase the performance speed on retrieval of data.
+      Valid values: INCREASE, DECREASE.
+    required: false # Optional in ISTP Guide
+    derived: false
+    overwrite: false
+    valid_values:
+      INCREASE
+      DECREASE
+    alternate: null
+  OPERATOR_TYPE:
+    description: >
+      This has been introduced to describe HERMES quaternions (see Section 5.2 below). It
+      has allowed values "UNIT_QUATERNION" or "ROTATION_MATRIX" although other
+      values could be added. Unit quaternions correspond to pure spatial rotations.
+    required: false
+    derived: false
+    overwrite: false
+    valid_values: null
+    alternate: null
+  REPRESENTATION_i:
+    description: >
+      This strongly recommended attribute holds the way vector or tensor variables are held,
+      e.g., as Cartesian or polar forms, and their sequence order in the dimension i in which
+      they are held. Cartesians are indicated by x,y,z; polar coordinates by r (magnitude), t
+      (theta - from z-axis), p (phi - longitude or azimuth around z-axis from x axis), l (lambda
+      = latitude). Examples follow.
+    required: false
+    derived: false
+    overwrite: false
+    valid_values: null
+    alternate: null
+  SCALEMIN:
+    description: >
+      are values which can be based on the actual values of data found in the CDF data set or on the probable uses of the data, {\em e.g.}, plotting multiple files at the same scale.
+      Visualization software can use these attributes as defaults for plotting.
+      The values must match the data type of the variable.
+    required: false # Optional in ISTP Guide
+    derived: false
+    overwrite: false
+    valid_values: null
+    alternate: null
+  SCALEMAX:
+    description: >
+      are values which can be based on the actual values of data found in the CDF data set or on the probable uses of the data, {\em e.g.}, plotting multiple files at the same scale.
+      Visualization software can use these attributes as defaults for plotting.
+      The values must match the data type of the variable.
+    required: false # Optional in ISTP Guide
+    derived: false
+    overwrite: false
+    valid_values: null
+    alternate: null
+  SCALETYP:
+    description: >
+      is a text string which describes the type of scaling that should be used for the variable.
+      The value of this attribute can be used with application software.
+      Examples are listed below:
+      - linear
+      - log
+    required: false # Optional in ISTP Guide
+    derived: false
+    overwrite: false
+    valid_values: null
+    alternate: null
+  SCAL_PTR:
+    description: >
+      The value of this field is a variable which stores the character string that represents the desired scaling type for the associated data.
+      The allowed values are linear and log.
+      The value of the attribute must be a variable in the same CDF data set.
+    required: false # Optional in ISTP Guide
+    derived: false
+    overwrite: false
+    valid_values: null
+    alternate: null
+  sig_digits:
+    description: >
+      This attribute provides the number of significant digits or other measure of data accuracy in a TBD manner.
+      It is to allow compression software to optimise the number of digits to retain, and users to assess the accuracy of products.
+      This operation is subject to the deliberations of the 'network traffic report' Task Group, DS-CFC-TN-0001, on compression algorithms and implementation.
+      Restrictions on data compression may also influence the format and choice of data type used by the CDF generation software.
+    required: false # Recommended in ISTP Guide
+    derived: false
+    overwrite: false
+    valid_values: null
+    alternate: null
   SI_CONVERSION:
     description: >
       The conversion factor to SI units. This is the factor that the variable must be multiplied
@@ -217,6 +498,45 @@ attribute_key:
     derived: true
     derivation_fn: _get_si_conversion
     required: false  # NOT Required in ISTP Guide
+    overwrite: false
+    valid_values: null
+    alternate: null
+  TENSOR_ORDER:
+    description: >
+      All variables which hold physical vectors, tensors, etc., or sub-parts thereof, are strongly
+      recommended to have their tensorial properties held by this numerical value. Vectors
+      have TENSOR_ORDER=1, pressure tensors have TENSOR_ORDER=2, etc. Variables
+      which hold single components or sub-parts of a vector or tensor, e.g., the x-component of
+      velocity or the three diagonal elements of a tensor, use this attribute to establish the
+      underlying object from which they are extracted. TENSOR_ORDER is a number, usually
+      held as a CDF_INT4, rather than a character string.
+    required: false
+    derived: false
+    overwrite: false
+    valid_values: null
+    alternate: null
+  TIMEDEL:
+    description: > 
+      This is a FITS WCS Keyword being repurposed for handling WCS transformations with 
+      high-dimensional or spectral CDF data variables. The value shall contain a floating
+      point number representing the resolution of the time stamps along the 0'th axis of 
+      the measurement. The TIMEDEL should match the CRDELi along the time axis of the 
+      measurement.
+    derived: true
+    derivation_fn: _get_wcs_timedel
+    required: false   # NOT Required in CDF Guide
+    overwrite: false
+    valid_values: null
+    alternate: null
+  TIMEUNIT:
+    description: > 
+      This is a FITS WCS Keyword being repurposed for handling WCS transformations with 
+      high-dimensional or spectral CDF data variables. The value shall contain a character
+      string giving the units of the time stamps along the 0'th axis of the measurement. 
+      The TIMEUNIT should match the CUNITi along the time axis of the measurement
+    derived: true
+    derivation_fn: _get_wcs_timeunit
+    required: false   # NOT Required in CDF Guide
     overwrite: false
     valid_values: null
     alternate: null
@@ -264,6 +584,15 @@ attribute_key:
     overwrite: false
     valid_values: null
     alternate: null
+  VAR_NOTES:
+    description: >
+      A text string that provides additional information about the variable.
+      This information can include the source of the data, the method of calculation, or any other information that is relevant to the variable.
+    required: false # Optional in ISTP Guide
+    derived: false
+    overwrite: false
+    valid_values: null
+    alternate: null
   VAR_TYPE:
     description: >
       Used in CDAWeb to indicate if the data should be used directly by users. 
@@ -277,7 +606,35 @@ attribute_key:
         metadata
         ignore_data
     alternate: null
-  # ===== SPECTRA-ONLY VARIABLE ATTRIBUTES =====
+  VARIABLE_PURPOSE:
+    description: >
+      are a list of tags/keywords separated by commas that indicate probable uses of the variable and its function.
+      Software can use these attributes to find the primary variables in the dataset, find variables with a common function, indicate variables suitable for specific purposes such as summary plots or educational displays, etc.
+      Tags could indicate a common geophysical quantity to enable matching several variables of the same kind.
+      For instance, all magnetic field variables could be tagged with VARIABLE_PURPOSE="Magnetic_Field" even though they have different coordinate systems or cadences.
+      Software could use this tag to identify variables with a common theme for easier distinguishing between groups of variables and selecting between them.
+      The values are always in a character string.
+      Suggested tags/keywords include:
+      - "PRIMARY_VAR": one of the primary variables in the dataset
+      - "EDUCATION": one of the variables suitable for displaying in an educational context
+      - "SUMMARY": one the variables to display on automatic summary plots
+      - "CARTESIAN", "ANGULAR": distinguish variables by coordinate system
+      - "Magnetic_Field", "Electric_Field", etc.: common instrument tag to relate similar variables
+    required: false # Optional in ISTP Guide
+    derived: false
+    overwrite: false
+    valid_values: null
+    alternate: null
+  V_PARENT:
+    description: >
+      identifies the "attached" variable which stores the parent variable(s) of a derived variable.
+      The "attached" variable can be dimensional and sized to hold as many parents as necessary.
+      The syntax of each entry would be: logical_file_id>variable_name.
+    required: false # Optional in ISTP Guide
+    derived: false
+    overwrite: false
+    valid_values: null
+    alternate: null
   WCSAXES:
     description: > 
       This is a FITS WCS Keyword being repurposed for handling WCS transformations with 
@@ -287,137 +644,6 @@ attribute_key:
       data array.
     derived: true
     derivation_fn: _get_wcs_naxis
-    required: false   # NOT Required in CDF Guide
-    overwrite: false
-    valid_values: null
-    alternate: null
-  MJDREF:
-    description: > 
-      This is a FITS WCS Keyword being repurposed for handling WCS transformations with 
-      high-dimensional or spectral CDF data variables. The value shall contain a floating
-      point number representing the reference time position of the time stamps along the 
-      0'th axis of the measurement.
-    derived: true
-    derivation_fn: _get_wcs_timeref
-    required: false   # NOT Required in CDF Guide
-    overwrite: false
-    valid_values: null
-    alternate: null
-  TIMEUNIT:
-    description: > 
-      This is a FITS WCS Keyword being repurposed for handling WCS transformations with 
-      high-dimensional or spectral CDF data variables. The value shall contain a character
-      string giving the units of the time stamps along the 0'th axis of the measurement. 
-      The TIMEUNIT should match the CUNITi along the time axis of the measurement
-    derived: true
-    derivation_fn: _get_wcs_timeunit
-    required: false   # NOT Required in CDF Guide
-    overwrite: false
-    valid_values: null
-    alternate: null
-  TIMEDEL:
-    description: > 
-      This is a FITS WCS Keyword being repurposed for handling WCS transformations with 
-      high-dimensional or spectral CDF data variables. The value shall contain a floating
-      point number representing the resolution of the time stamps along the 0'th axis of 
-      the measurement. The TIMEDEL should match the CRDELi along the time axis of the 
-      measurement.
-    derived: true
-    derivation_fn: _get_wcs_timedel
-    required: false   # NOT Required in CDF Guide
-    overwrite: false
-    valid_values: null
-    alternate: null
-  CNAMEi:
-    description: > 
-      This is a FITS WCS Keyword being repurposed for handling WCS transformations with 
-      high-dimensional or spectral CDF data variables. This metadata attribte should be 
-      used for the i'th dimension (1-based) and reapeated for all WCSAXES dimensions. 
-      The value shall contain a charachter string represnting the name of the i'th axis.
-      The name is used for comment/documentation purposes only and is not used as a part
-      of the i'th axis coordinate transformations.
-    derived: true
-    derivation_fn: _get_cnamei
-    iterable: true
-    required: false   # NOT Required in CDF Guide
-    overwrite: false
-    valid_values: null
-    alternate: null
-  CTYPEi:
-    description: > 
-      This is a FITS WCS Keyword being repurposed for handling WCS transformations with 
-      high-dimensional or spectral CDF data variables. This metadata attribte should be 
-      used for the i'th dimension (1-based) and reapeated for all WCSAXES dimensions. 
-      The value field shall contain a character string, giving
-      the name of the coordinate represented by axis i.
-    derived: true
-    derivation_fn: _get_ctypei
-    iterable: true
-    required: false   # NOT Required in CDF Guide
-    overwrite: false
-    valid_values: null
-    alternate: null
-  CUNITi:
-    description: > 
-      This is a FITS WCS Keyword being repurposed for handling WCS transformations with 
-      high-dimensional or spectral CDF data variables. This metadata attribte should be 
-      used for the i'th dimension (1-based) and reapeated for all WCSAXES dimensions. 
-      The value shall be the units along axis i, compatible with CTYPEi to be used for
-      scaling and coordinate transformations along the i'th axis. 
-    derived: true
-    derivation_fn: _get_cuniti
-    iterable: true
-    required: false   # NOT Required in CDF Guide
-    overwrite: false
-    valid_values: null
-    alternate: null
-  CRPIXi:
-    description: > 
-      This is a FITS WCS Keyword being repurposed for handling WCS transformations with 
-      high-dimensional or spectral CDF data variables. This metadata attribte should be 
-      used for the i'th dimension (1-based) and reapeated for all WCSAXES dimensions. 
-      The value field shall contain a floating point number, 
-      identifying the location of a reference point along axis i, in units of
-      the axis index.  This value is based upon a counter that runs from 1 to
-      NAXISn with an increment of 1 per pixel.  The reference point value
-      need not be that for the center of a pixel nor lie within the actual
-      data array.  Use comments to indicate the location of the index point
-      relative to the pixel.
-    derived: true
-    derivation_fn: _get_crpixi
-    iterable: true
-    required: false   # NOT Required in CDF Guide
-    overwrite: false
-    valid_values: null
-    alternate: null
-  CRVALi:
-    description: > 
-      This is a FITS WCS Keyword being repurposed for handling WCS transformations with 
-      high-dimensional or spectral CDF data variables. This metadata attribte should be 
-      used for the i'th dimension (1-based) and reapeated for all WCSAXES dimensions. 
-      The value field shall contain a floating point number,
-      giving the value of the coordinate specified by the CTYPEn keyword at
-      the reference point CRPIXi.
-    derived: true
-    derivation_fn: _get_crvali
-    iterable: true
-    required: false   # NOT Required in CDF Guide
-    overwrite: false
-    valid_values: null
-    alternate: null
-  CDELTi:
-    description: > 
-      This is a FITS WCS Keyword being repurposed for handling WCS transformations with 
-      high-dimensional or spectral CDF data variables. This metadata attribte should be 
-      used for the i'th dimension (1-based) and reapeated for all WCSAXES dimensions. 
-      The value field shall contain a floating point number 
-      giving the partial derivative of the coordinate specified by the CTYPEi 
-      keywords with respect to the pixel index, evaluated at the reference 
-      point CRPIXi, in units of the coordinate specified by  the CTYPEi 
-      keyword.
-    derived: true
-    derivation_fn: _get_cdelti
-    iterable: true
     required: false   # NOT Required in CDF Guide
     overwrite: false
     valid_values: null

--- a/swxsoc/util/schema.py
+++ b/swxsoc/util/schema.py
@@ -11,11 +11,14 @@ from copy import deepcopy
 from typing import Optional
 import math
 import yaml
+
 import numpy as np
 from astropy.table import Table
 from astropy.time import Time
 from astropy import units as u
 from ndcube import NDCube
+
+from sammi.schema import SWxSchema
 import swxsoc
 from swxsoc import log
 from swxsoc.util import util, const
@@ -27,7 +30,7 @@ DEFAULT_GLOBAL_CDF_ATTRS_SCHEMA_FILE = "swxsoc_default_global_cdf_attrs_schema.y
 DEFAULT_VARIABLE_CDF_ATTRS_SCHEMA_FILE = "swxsoc_default_variable_cdf_attrs_schema.yaml"
 
 
-class SWXSchema:
+class SWXSchema(SWxSchema):
     """
     Class representing a schema for data requirements and formatting. The SWxSOC Default Schema
     only includes attributes required for ISTP compliance. Additional mission-specific attributes
@@ -124,57 +127,38 @@ class SWXSchema:
         variable_schema_layers: Optional[list[str]] = None,
         use_defaults: Optional[bool] = True,
     ):
-        super().__init__()
 
-        # Data Validation, Compliance, Derived Attributes
-        if not use_defaults and (
-            global_schema_layers is None
-            or variable_schema_layers is None
-            or len(global_schema_layers) == 0
-            or len(variable_schema_layers) == 0
-        ):
-            raise ValueError(
-                "Not enough information to create schema. You must either use the defaults or provide alternative layers for both global and variable attribbute schemas."
-            )
+        # SWxSOC Default Global Schema
+        global_schema_path = str(
+            Path(swxsoc.__file__).parent / "data" / DEFAULT_GLOBAL_CDF_ATTRS_SCHEMA_FILE
+        )
+        # SWxSOC Default Variable Schema
+        variable_schema_path = str(
+            Path(swxsoc.__file__).parent
+            / "data"
+            / DEFAULT_VARIABLE_CDF_ATTRS_SCHEMA_FILE
+        )
 
-        # Construct the Global Attribute Schema
-        _global_attr_schema = {}
-        if use_defaults:
-            _def_global_attr_schema = self._load_default_global_attr_schema()
-            _global_attr_schema = self._merge(
-                base_layer=_global_attr_schema, new_layer=_def_global_attr_schema
-            )
-        if global_schema_layers is not None:
-            for schema_layer_path in global_schema_layers:
-                _global_attr_layer = self._load_yaml_data(
-                    yaml_file_path=schema_layer_path
-                )
-                _global_attr_schema = self._merge(
-                    base_layer=_global_attr_schema, new_layer=_global_attr_layer
-                )
-        # Set Final Member
-        self._global_attr_schema = _global_attr_schema
+        # Seed Layers with Default
+        if not use_defaults:
+            _global_schema_layers = []
+            _variable_schema_layers = []
+        else:
+            _global_schema_layers = [global_schema_path]
+            _variable_schema_layers = [variable_schema_path]
 
-        # Data Validation and Compliance for Variable Data
-        _variable_attr_schema = {}
-        if use_defaults:
-            _def_variable_attr_schema = self._load_default_variable_attr_schema()
-            _variable_attr_schema = self._merge(
-                base_layer=_variable_attr_schema, new_layer=_def_variable_attr_schema
-            )
-        if variable_schema_layers is not None:
-            for schema_layer_path in variable_schema_layers:
-                _variable_attr_layer = self._load_yaml_data(
-                    yaml_file_path=schema_layer_path
-                )
-                _variable_attr_schema = self._merge(
-                    base_layer=_variable_attr_schema, new_layer=_variable_attr_layer
-                )
-        # Set the Final Member
-        self._variable_attr_schema = _variable_attr_schema
+        # Extend Custom Layers
+        if global_schema_layers is not None and len(global_schema_layers) > 0:
+            _global_schema_layers.extend(global_schema_layers)
+        if variable_schema_layers is not None and len(variable_schema_layers) > 0:
+            _variable_schema_layers.extend(variable_schema_layers)
 
-        # Load Default Global Attributes
-        self._default_global_attributes = self._load_default_attributes()
+        # Call SAMMI Initialization to populate Schema
+        super().__init__(
+            global_schema_layers=_global_schema_layers,
+            variable_schema_layers=_variable_schema_layers,
+            use_defaults=use_defaults,
+        )
 
         self.cdftypenames = {
             const.CDF_BYTE.value: "CDF_BYTE",
@@ -231,69 +215,6 @@ class SWXSchema:
             ("CRVAL", "crval", 1),
             ("CDELT", "cdelt", 1),
         ]
-
-    @property
-    def global_attribute_schema(self):
-        """(`dict`) Schema for variable attributes of the file."""
-        return self._global_attr_schema
-
-    @property
-    def variable_attribute_schema(self):
-        """(`dict`) Schema for variable attributes of the file."""
-        return self._variable_attr_schema
-
-    @property
-    def default_global_attributes(self):
-        """(`dict`) Default Global Attributes applied for all SWxSOC Data Files"""
-        return self._default_global_attributes
-
-    def _load_default_global_attr_schema(self) -> dict:
-        # The Default Schema file is contained in the `swxsoc/data` directory
-        default_schema_path = str(
-            Path(swxsoc.__file__).parent / "data" / DEFAULT_GLOBAL_CDF_ATTRS_SCHEMA_FILE
-        )
-        # Load the Schema
-        return self._load_yaml_data(yaml_file_path=default_schema_path)
-
-    def _load_default_variable_attr_schema(self) -> dict:
-        # The Default Schema file is contained in the `swxsoc/data` directory
-        default_schema_path = str(
-            Path(swxsoc.__file__).parent
-            / "data"
-            / DEFAULT_VARIABLE_CDF_ATTRS_SCHEMA_FILE
-        )
-        # Load the Schema
-        return self._load_yaml_data(yaml_file_path=default_schema_path)
-
-    def _load_default_attributes(self) -> dict:
-        # Use the Existing Global Schema
-        global_schema = self.global_attribute_schema
-        return {
-            attr_name: info["default"]
-            for attr_name, info in global_schema.items()
-            if info["default"] is not None
-        }
-
-    def _load_yaml_data(self, yaml_file_path: str) -> dict:
-        """
-        Function to load data from a Yaml file.
-
-        Parameters
-        ----------
-        yaml_file_path: `str`
-            Path to schem file to be used for CDF formatting.
-
-        """
-        assert isinstance(yaml_file_path, str)
-        assert Path(yaml_file_path).exists()
-        # Load the Yaml file to Dict
-        yaml_data = {}
-        with open(yaml_file_path, "r") as f:
-            try:
-                yaml_data = yaml.safe_load(f)
-            except yaml.YAMLError as exc:
-                log.critical(exc)
-        return yaml_data
 
     def global_attribute_template(self) -> OrderedDict:
         """

--- a/swxsoc/util/tests/test_schema.py
+++ b/swxsoc/util/tests/test_schema.py
@@ -1,6 +1,7 @@
 import pytest
 import tempfile
 from collections import OrderedDict
+import yaml
 import numpy as np
 from numpy.random import random
 from astropy.time import Time
@@ -102,8 +103,8 @@ def test_load_yaml_data():
             file.write(invalid_yaml)
 
         # Load from an non-existant file
-        yaml_data = SWXSchema()._load_yaml_data(tmpdirname + "test.yaml")
-        assert yaml_data == {}
+        with pytest.raises(yaml.YAMLError):
+            _ = SWXSchema()._load_yaml_data(tmpdirname + "test.yaml")
 
 
 def test_global_attributes():

--- a/swxsoc/util/tests/test_validation.py
+++ b/swxsoc/util/tests/test_validation.py
@@ -129,7 +129,7 @@ def test_missing_variable_attrs():
         )
         assert (
             "Variable: measurement Attribute 'DISPLAY_TYPE' not one of valid options.",
-            "Was bad_type, expected one of time_series time_series>noerrorbars spectrogram stack_plot image",
+            "Was bad_type, expected one of time_series time_series>noerrorbars spectrogram stack_plot image no_plot",
         ) in result
 
 

--- a/swxsoc/util/validation.py
+++ b/swxsoc/util/validation.py
@@ -138,13 +138,13 @@ class CDFValidator(SWXDataValidator):
         # Loop for each attribute in the schema
         for attr_name, attr_schema in self.schema.global_attribute_schema.items():
             # If it is a required attribute and not present
-            if attr_schema["validate"] and (attr_name not in cdf_file.attrs):
+            if attr_schema["required"] and (attr_name not in cdf_file.attrs):
                 global_attr_validation_errors.append(
                     f"Required attribute ({attr_name}) not present in global attributes.",
                 )
             # If it is a required attribute but null
             if (
-                attr_schema["validate"]
+                attr_schema["required"]
                 and (attr_name in cdf_file.attrs)
                 and (
                     (cdf_file.attrs[attr_name][0] == "")


### PR DESCRIPTION
Updates schema to use `sammi-cdf` Shared Attribute and Metadata Management Interface. 
- Updates local schema YAML files to match upstream YAML files. 
- Removes the `validate` keyword since its no longer needed and we can use the `required` keyword for validation