### PR TITLE
Update Parfive Requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   'sunpy[all]>=5.0.1',
   'spacepy>=0.5.0',
   'ndcube>=2.2.0',
-  'parfive==2.1.0',
+  'parfive>=2.1.0',
   'pyyaml>=5.3.1',
   'boto3>=1.35.26'
 ]


### PR DESCRIPTION
Updates the `parfive` version requirement from `==2.1.0` to `>=2.1.0`. This is to support installing `swxsoc` in the PyHC environment as a part of adding the `swxsoc` package to the PyHC ecosystem in https://github.com/heliophysicsPy/heliophysicsPy.github.io/pull/366. 