### PR TITLE
Fix an issue with pipeline

### DIFF
--- a/swxsoc/util/tests/test_util.py
+++ b/swxsoc/util/tests/test_util.py
@@ -351,7 +351,7 @@ def test_parse_env_var_configured_2(filename, instrument, time, level, version, 
     ("padreMDA0_000107034739.idx", "meddea", "2000-01-07 03:47:39", "raw", None, None),
     ("padreMDU8_000107034739.dat", "meddea", "2000-01-07 03:47:39", "raw", None, None),
     ("padreMDU8_000107034739.idx", "meddea", "2000-01-07 03:47:39", "raw", None, None),
-    ("padre_meddea_l0test_light_20250131T192102_v0.3.0.bin", "meddea", "2025-01-31T19:21:02.000", "raw", None, None),
+    ("padre_meddea_l0test_light_20250131T192102_v0.3.0.bin", "meddea", "2025-01-31 19:21:02", "raw", None, None),
     ("padre_sharp_ql_20230430T000000_v0.0.1.fits", "sharp", "2023-04-30T00:00:00.000", "ql", "0.0.1", None),
     ("padre_processing_FRAME_210_Data_1762019705243_1762198944388.csv", "craft", "2025-11-01T17:55:05.243", "raw", None, None),
     ("padre_get_EPS2_BP_INST0_CHARGER_XP_Data_1762019652327_1762198944391.csv", "craft", "2025-11-01T17:54:12.327", "raw", None, None),
@@ -369,6 +369,7 @@ def test_parse_padre_science_files(filename, instrument, time, level, version, m
     assert result['level'] == level
     assert result['version'] == version
     assert result['time'].isot == Time(time).isot  # compare str otherwise breaks for unix time
+    assert str(result['time']) == str(time)
     assert result['mode'] == mode
 # fmt: on
 

--- a/swxsoc/util/util.py
+++ b/swxsoc/util/util.py
@@ -298,7 +298,9 @@ def _extract_time(filename: str) -> Time:
         if matches:
             time_str = matches.group(0)
             if len(time_str) == 13:
-                return Time(int(time_str) / 1000.0, format="unix")
+                t_unix = Time(int(time_str) / 1000.0, format="unix")
+                t_unix.format = "isot"  # fix the string representation
+                return t_unix
             # Try legacy L0 formats first
             for fmt in L0_TIME_FORMATS:
                 try:


### PR DESCRIPTION
The string representation of a unix time is a float instead of a string.