### PR TITLE
Bug fix for bad time match

### DIFF
--- a/swxsoc/util/tests/test_util.py
+++ b/swxsoc/util/tests/test_util.py
@@ -357,6 +357,7 @@ def test_parse_env_var_configured_2(filename, instrument, time, level, version, 
     ("padre_get_EPS2_BP_INST0_CHARGER_XP_Data_1762019652327_1762198944391.csv", "craft", "2025-11-01T17:54:12.327", "raw", None, None),
     ("padre_get_EPS2_BP_INST0_CHARGER_YP_Data_1762019652327_1762198944391.csv", "craft", "2025-11-01T17:54:12.327", "raw", None, None),
     ("padre_get_EPS_9_Data_1762008094193_1762187403300.csv", "craft", "2025-11-01T14:41:34.193", "raw", None, None),
+    ("padre_get_EPS_9_Data_1763282491281_1836308076540.csv", "craft", "2025-11-16T08:41:31.281", "raw", None, None),
 ])
 def test_parse_padre_science_files(filename, instrument, time, level, version, mode):
     """Testing parsing of MOC-generated level 0 files."""
@@ -372,6 +373,11 @@ def test_parse_padre_science_files(filename, instrument, time, level, version, m
     assert str(result['time']) == str(time)
     assert result['mode'] == mode
 # fmt: on
+
+
+def test_extract_time_warning(caplog):
+    util._extract_time("padre_get_EPS_9_Data_1836308076540_1836308076540.csv")
+    assert "Found future time" in caplog.text
 
 
 # fmt: off

--- a/swxsoc/util/util.py
+++ b/swxsoc/util/util.py
@@ -285,12 +285,14 @@ def _extract_time(filename: str) -> Time:
     """
 
     TIME_PATTERNS = [
+        re.compile(
+            r"\d{13}"
+        ),  # unix time stamps in milliseconds, check for this first so that it does not get confused with other patterns
         re.compile(r"\d{8}[-_ T]?\d{6}"),  # YYYYMMDD-HHMMSS
         re.compile(r"\d{4}-\d{2}-\d{2}[-_ T]\d{2}:\d{2}:\d{2}"),  # ISO 8601
         re.compile(r"\d{7}[-_]\d{6}"),  # Legacy L0 formats
         re.compile(r"\d{12}"),  # YYMMDDhhmmss
         re.compile(r"\d{8}T\d{6}"),  # YYYYMMDDTHHMMSS (added this line)
-        re.compile(r"\d{13}"),  # unix time stamps in milliseconds
     ]
 
     for pattern in TIME_PATTERNS:
@@ -300,6 +302,8 @@ def _extract_time(filename: str) -> Time:
             if len(time_str) == 13:
                 t_unix = Time(int(time_str) / 1000.0, format="unix")
                 t_unix.format = "isot"  # fix the string representation
+                if t_unix > Time.now():
+                    swxsoc.log.warning(f"Found future time {t_unix}.")
                 return t_unix
             # Try legacy L0 formats first
             for fmt in L0_TIME_FORMATS:


### PR DESCRIPTION
Certain combinations of two unix time strings could be confused as another time format. For examples 1763282491281_1836308076540 matches YYYYJJJ_HHMMSS.