### PR TITLE
Add Function to Get Package Name

### DIFF
--- a/swxsoc/data/config.yml
+++ b/swxsoc/data/config.yml
@@ -15,8 +15,10 @@ general:
 selected_mission: demo
 
 missions_data:
-  demo: # A generic mission template for testing
+  demo: # A generic mission template for demonstration
     file_extension: cdf # The File Extension Used for Archive Files and Science File Formats
+    min_valid_time: 2020-01-01T00:00:00 # The Minimum Valid Time for this Mission (in ISO8601 format)
+    max_valid_time: now # The Maximum Valid Time for this Mission (in ISO8601 format, or "now" for the current time)
     valid_data_levels: # List of Valid Data Levels for this Mission
       - l0
       - ql
@@ -24,10 +26,27 @@ missions_data:
       - l2
       - l3
     instruments: # List of Instruments for this Mission
-      - name: MyInstrument # The name of the instrument
+      - name: MyInstrument1 # The name of the instrument
+        instrument_package: demo_myinst1 # The name of the instrument package (if different from the {mission}_{instrument} name)
         shortname: myinst # The short name of the instrument
         fullname: My Instrument Full Name # The full name of the instrument (to be used in plots, metadata, etc)
         targetname: MYINST # The target name of the instrument (to be used in file paths, etc)
+      - name: MyInstrument2
+        shortname: myinst2
+        fullname: My Instrument 2 Full Name
+        targetname: MYINST2
+        extra_inst_names: # contains extra names that can be used to refer to this instrument (e.g. in file paths, etc)
+          - myinst2_altname1
+          - myinst2_altname2
+        file_rules: # A list of rules for how to interpret files for this instrument. 
+          # Raw Data (specific to .dat files)
+          - levels: [raw] # The data levels that this rule applies to (can be a list of levels)
+            extension: .dat # The file extension that this rule applies to
+            time_format: "%y%m%d%H%M%S" # The time format to use for parsing the time from the file name (using strptime format codes)
+          # Processed Files (Science / Standard Format Files)
+          - levels: [l0, l1, ql, l2, l3] # The data levels that this rule applies to (can be a list of levels)
+            extension: .fits # The file extension that this rule applies to
+            time_format: "%Y%m%dT%H%M%S" # The time format to use for parsing the time from the file name (using strptime format codes)
 
   hermes:
     file_extension: cdf

--- a/swxsoc/data/config.yml
+++ b/swxsoc/data/config.yml
@@ -120,6 +120,7 @@ missions_data:
         shortname: reach
         fullname: REACH
         targetname: REACH
+        instrument_package: swxsoc_reach
         file_rules:
           # SWxSOC Input Data (CSV Files) is already processed to a Level 1
           - levels: [l1]

--- a/swxsoc/util/config.py
+++ b/swxsoc/util/config.py
@@ -100,6 +100,10 @@ def load_config():
             for inst in mission_data.get("instruments", [])
             if "extra_inst_names" in inst
         ],
+        "inst_packages": {
+            inst["name"]: inst.get("instrument_package", None)
+            for inst in mission_data.get("instruments", [])
+        },
         "inst_file_rules": {
             inst["name"]: inst.get("file_rules", [])
             for inst in mission_data.get("instruments", [])

--- a/swxsoc/util/tests/test_config.py
+++ b/swxsoc/util/tests/test_config.py
@@ -97,8 +97,8 @@ def test_load_config_missing_valid_time_fields(use_mission):
 
     assert "min_valid_time" in mission_config
     assert "max_valid_time" in mission_config
-    assert mission_config["min_valid_time"] is None
-    assert mission_config["max_valid_time"] is None
+    assert mission_config["min_valid_time"] == Time("2020-01-01T00:00:00")
+    assert mission_config["max_valid_time"].isclose(Time.now(), atol=1.0 * u.min)
 
 
 def test_load_config_lambda_env(monkeypatch):

--- a/swxsoc/util/tests/test_config.py
+++ b/swxsoc/util/tests/test_config.py
@@ -46,6 +46,8 @@ def test_load_config_defaults(monkeypatch):
     assert "inst_fullnames" in mission_config
     assert "inst_targetnames" in mission_config
     assert "extra_inst_names" in mission_config
+    # Check Instrument Packages
+    assert "inst_packages" in mission_config
     # Check file rules
     assert "inst_file_rules" in mission_config
     # Check mapping dictionaries
@@ -72,6 +74,8 @@ def test_load_config_mission_override():
     assert mission_config["mission_name"] == "hermes"
     # Check that it actually loaded hermes-specific data (e.g. instruments)
     assert "eea" in mission_config["inst_names"]
+    # check instrument packages
+    assert "inst_packages" in mission_config
     # Check that file_rules exists
     assert "inst_file_rules" in mission_config
     assert isinstance(mission_config["inst_file_rules"], dict)
@@ -128,6 +132,7 @@ def test_load_config_unknown_mission(monkeypatch):
     assert mission_config["inst_targetnames"] == []
     assert mission_config["extra_inst_names"] == []
     # Should have empty dicts for mappings and file rules
+    assert mission_config["inst_packages"] == {}
     assert mission_config["inst_file_rules"] == {}
     assert mission_config["inst_to_shortname"] == {}
     assert mission_config["inst_to_fullname"] == {}

--- a/swxsoc/util/tests/test_util.py
+++ b/swxsoc/util/tests/test_util.py
@@ -289,6 +289,36 @@ def test_extract_time_warnings(use_mission, filename, expected_warning, caplog):
     assert expected_warning in caplog.text
 
 
+def test_get_instrument_package_hermes(use_mission):
+    # Mission: hermes
+    assert util.get_instrument_package("eea") == "hermes_eea"
+    assert util.get_instrument_package("EEA") == "hermes_eea"
+    assert util.get_instrument_package("nemisis") == "hermes_nemisis"
+    assert util.get_instrument_package("Nemisis") == "hermes_nemisis"
+    with pytest.raises(ValueError):
+        util.get_instrument_package("not_an_inst")
+
+
+@pytest.mark.parametrize("use_mission", ["padre"], indirect=True)
+def test_get_instrument_package_padre(use_mission):
+    # Mission: padre
+    assert util.get_instrument_package("meddea") == "padre_meddea"
+    assert util.get_instrument_package("MEDDEA") == "padre_meddea"
+    assert util.get_instrument_package("sharp") == "padre_sharp"
+    assert util.get_instrument_package("SHARP") == "padre_sharp"
+    with pytest.raises(ValueError):
+        util.get_instrument_package("fake")
+
+
+@pytest.mark.parametrize("use_mission", ["swxsoc_pipeline"], indirect=True)
+def test_get_instrument_package_swxsoc_pipeline(use_mission):
+    # Mission: swxsoc_pipeline
+    assert util.get_instrument_package("reach") == "swxsoc_reach"
+    assert util.get_instrument_package("REACH") == "swxsoc_reach"
+    with pytest.raises(ValueError):
+        util.get_instrument_package("unknown")
+
+
 @mock_aws
 def test_search_all_attr():
     # HERMES mission is set by default via autouse fixture in conftest.py

--- a/swxsoc/util/util.py
+++ b/swxsoc/util/util.py
@@ -653,6 +653,49 @@ def parse_science_filename(filepath: str) -> dict:
     return result
 
 
+def get_instrument_package(instrument_name: str) -> str:
+    """
+    Determines the package name of the correct instrument package to use for processing a file based on the instrument name.
+    This is determined through two possibilities:
+    1. The instrument name is directly mapped to a package in the instrument configuration under "instrument_package".
+    2. The package is default determined by "{mission__name}_{instrument_name}"
+
+    Parameters
+    ----------
+    instrument_name : str
+        The name of the instrument to find the package for.
+
+    Returns
+    -------
+    str
+        The name of the package to use for processing files from the specified instrument.
+
+    Raises
+    ------
+    ValueError
+        If the instrument name is not recognized as one of the mission's instruments.
+    """
+    mission_config = swxsoc.config["mission"]
+
+    # sanitize instrument name for matching (e.g. case insensitive)
+    instrument_name = instrument_name.lower()
+
+    # check if the instrument is available for the mission
+    if instrument_name not in mission_config["inst_names"]:
+        raise ValueError(
+            f"Instrument, {instrument_name}, is not recognized. Must be one of {list(mission_config['inst_names'])}."
+        )
+
+    # get the instrument configuration
+    inst_package = mission_config["inst_packages"].get(instrument_name)
+    if inst_package:
+        # if a package is explicitly defined for the instrument, use it
+        return inst_package
+    else:
+        # otherwise, default to the convention of {mission_name}_{instrument_name}
+        return f"{mission_config['mission_name'].lower()}_{instrument_name.lower()}"
+
+
 # ================================================================================================
 #                                  SWXSOC FIDO CLIENT
 # ================================================================================================


### PR DESCRIPTION
### Added
- **New utility function:** `get_instrument_package(instrument_name)` in util.py  
  Determines the correct Python package name for a given instrument, using either an explicit `instrument_package` config or the default `{mission_name}_{instrument_name}` convention. Raises a `ValueError` for unknown instruments.  
- **Unit tests:** Added comprehensive tests for `get_instrument_package` covering:
  - Explicit package mapping
  - Default fallback
  - Case-insensitivity
  - Error handling for unknown instruments  
  Tests are parameterized for HERMES, PADRE, and SWxSOC Pipeline missions.

### Changed
- **Config parsing:**  
  - `inst_packages` is now always present in mission config, mapping instrument names to their package (or `None` if not set).

closes #68