### PR TITLE
Add Unix Timestamp (Seconds) Parsing

### DIFF
--- a/swxsoc/util/tests/test_util.py
+++ b/swxsoc/util/tests/test_util.py
@@ -205,6 +205,8 @@ def test_parse_l0_filenames_hermes(filename, instrument, time, level, version, m
     ("padre_get_EPS2_BP_INST0_CHARGER_YP_Data_1762019652327_1762198944391.csv", "craft", "2025-11-01T17:54:12.327", "raw", None, None),
     ("padre_get_EPS_9_Data_1762008094193_1762187403300.csv", "craft", "2025-11-01T14:41:34.193", "raw", None, None),
     ("padre_get_EPS_9_Data_1763282491281_1836308076540.csv", "craft", "2025-11-16T08:41:31.281", "raw", None, None),
+    ("padre_craft_dirlist_1772908542.txt", "craft", "2026-03-07T18:35:42.000", "raw", None, None),
+    ("padre_craft_dirlist_1772908542.csv", "craft", "2026-03-07T18:35:42.000", "raw", None, None),
 ])
 def test_parse_padre_science_files(use_mission, filename, instrument, time, level, version, mode):
     """Testing parsing of MOC-generated level 0 files."""

--- a/swxsoc/util/util.py
+++ b/swxsoc/util/util.py
@@ -51,6 +51,7 @@ TIME_FORMAT = "%Y%m%dT%H%M%S"  # YYYYMMDDTHHMMSS
 
 TIME_PATTERNS = {
     "unix_ms": re.compile(r"(?<!\d)\d{13}(?!\d)"),  # unix time stamps in milliseconds
+    "unix_s": re.compile(r"(?<!\d)\d{10}(?!\d)"),  # unix time stamps in seconds
     "%Y-%m-%dT%H:%M:%S": re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"),  # ISO 8601
     "%Y%m%d-%H%M%S": re.compile(r"\d{8}-\d{6}"),  # YYYYMMDD-HHMMSS
     "%Y%m%dT%H%M%S": re.compile(r"\d{8}T\d{6}"),  # YYYYMMDDTHHMMSS
@@ -406,6 +407,9 @@ def _try_parse_with_expected_format(
     # Look for a match in the filename using the expected format
     match = pattern.search(filename)
     if not match:
+        swxsoc.log.warning(
+            f"No time string matching expected format '{expected_format}' found in {filename}."
+        )
         return None
 
     time_str = match.group(0)
@@ -461,8 +465,8 @@ def _parse_time_string(time_str: str, format_str: str) -> Optional[Time]:
     >>> _parse_time_string("invalid", "%Y-%m-%d")
     """
     # Special case for unix time
-    if format_str == "unix_ms":
-        return _parse_unix_timestamp(time_str)
+    if format_str in ("unix_ms", "unix_s"):
+        return _parse_unix_timestamp(time_str, format_str)
 
     # Try datetime string formatters
     try:
@@ -477,14 +481,16 @@ def _parse_time_string(time_str: str, format_str: str) -> Optional[Time]:
         return None
 
 
-def _parse_unix_timestamp(time_str: str) -> Time:
+def _parse_unix_timestamp(time_str: str, format_str: str) -> Time:
     """
-    Parse Unix timestamp in milliseconds.
+    Parse Unix timestamp in milliseconds or seconds.
 
     Parameters
     ----------
     time_str : str
-        The Unix timestamp string in milliseconds.
+        The Unix timestamp string.
+    format_str : str
+        The format identifier: ``"unix_ms"`` for milliseconds, or ``"unix_s"`` for seconds.
 
     Returns
     -------
@@ -493,10 +499,13 @@ def _parse_unix_timestamp(time_str: str) -> Time:
 
     Examples
     --------
-    >>> _parse_unix_timestamp("1673785845000")
+    >>> _parse_unix_timestamp("1673785845000", "unix_ms")
+    <Time object: scale='utc' format='isot' value=2023-01-15T12:30:45.000>
+    >>> _parse_unix_timestamp("1673785845", "unix_s")
     <Time object: scale='utc' format='isot' value=2023-01-15T12:30:45.000>
     """
-    t_unix = Time(int(time_str) / 1000.0, format="unix")
+    divisor = 1000.0 if format_str == "unix_ms" else 1.0
+    t_unix = Time(int(time_str) / divisor, format="unix")
     t_unix.format = "isot"  # Need to set format to isot for consistency
     return t_unix
 


### PR DESCRIPTION
- Added support for parsing Unix timestamps in seconds (``unix_s``) in addition to
  the existing milliseconds (``unix_ms``) format. This enables parsing filenames
  such as ``padre_craft_dirlist_1772908542.txt`` that contain 10-digit Unix
  timestamps. (`swxsoc/util/util.py`)

New Functionality:

- Added ``"unix_s"`` entry to ``TIME_PATTERNS`` matching 10-digit Unix timestamps.

Changed Functionality:

- ``_parse_unix_timestamp()`` now accepts a required ``format_str`` parameter
  (``"unix_ms"`` or ``"unix_s"``) to determine whether to divide by 1000.
  Previously it only handled milliseconds and took no format argument.
- ``_parse_time_string()`` now routes both ``"unix_ms"`` and ``"unix_s"``
  format strings to ``_parse_unix_timestamp()``, passing the format through.