### PR TITLE
Update REACH Config

### DIFF
--- a/swxsoc/data/config.yml
+++ b/swxsoc/data/config.yml
@@ -128,7 +128,6 @@ missions_data:
   # This is a collection of multuple instruments and missions grouped together for convenience.
     file_extension: cdf
     valid_data_levels:
-      - raw
       - l1c
       - l2
       - l3

--- a/swxsoc/data/config.yml
+++ b/swxsoc/data/config.yml
@@ -141,10 +141,10 @@ missions_data:
           # SWxSOC Input Data (CSV & JSON Files) is already processed to a Level 1C
           - levels: [l1c]
             extension: .csv
-            time_format: "%Y%m%d"
+            time_format: "%Y%m%dT%H%M%S"
           - levels: [l1c]
             extension: .json
-            time_format: "%Y%m%d"
+            time_format: "%Y%m%dT%H%M%S"
 
 logger:
   # Threshold for the logging messages. Logging messages that are less severe

--- a/swxsoc/data/config.yml
+++ b/swxsoc/data/config.yml
@@ -129,9 +129,7 @@ missions_data:
     file_extension: cdf
     valid_data_levels:
       - raw
-      - l0
-      - ql
-      - l1
+      - l1c
       - l2
       - l3
     instruments:
@@ -141,9 +139,12 @@ missions_data:
         targetname: REACH
         instrument_package: swxsoc_reach
         file_rules:
-          # SWxSOC Input Data (CSV Files) is already processed to a Level 1
-          - levels: [l1]
+          # SWxSOC Input Data (CSV & JSON Files) is already processed to a Level 1C
+          - levels: [l1c]
             extension: .csv
+            time_format: "%Y%m%d"
+          - levels: [l1c]
+            extension: .json
             time_format: "%Y%m%d"
 
 logger:

--- a/swxsoc/data/config.yml
+++ b/swxsoc/data/config.yml
@@ -128,6 +128,7 @@ missions_data:
   # This is a collection of multuple instruments and missions grouped together for convenience.
     file_extension: cdf
     valid_data_levels:
+      - raw
       - l1c
       - l2
       - l3
@@ -139,10 +140,10 @@ missions_data:
         instrument_package: swxsoc_reach
         file_rules:
           # SWxSOC Input Data (CSV & JSON Files) is already processed to a Level 1C
-          - levels: [l1c]
+          - levels: [raw]
             extension: .csv
             time_format: "%Y%m%dT%H%M%S"
-          - levels: [l1c]
+          - levels: [raw]
             extension: .json
             time_format: "%Y%m%dT%H%M%S"
 

--- a/swxsoc/util/tests/test_util.py
+++ b/swxsoc/util/tests/test_util.py
@@ -223,11 +223,11 @@ def test_parse_padre_science_files(use_mission, filename, instrument, time, leve
 @pytest.mark.parametrize("use_mission", ["swxsoc_pipeline"], indirect=True)
 @pytest.mark.parametrize("filename,instrument,time,level,version,mode,descriptor", [
     # Standard format CDF file with underscore in mission name
-    ("swxsoc_pipeline_reach_all_l1_20251201T000000_v2.0.0.cdf", "reach", "2025-12-01T00:00:00.000", "l1", "2.0.0", "all", None),
-    # CSV file matching file_rules for REACH (l1, %Y%m%d format)
-    ("REACH-all_20251201.csv", "reach", "2025-12-01T00:00:00.000", "l1", None, None, None),
-    # JSON file with no matching rule (Case 3 fallback)
-    ("REACH-all_20251201.json", "reach", "2025-12-01T00:00:00.000", "raw", None, None, None),
+    ("swxsoc_pipeline_reach_all_l1c_20251201T000000_v2.0.0.cdf", "reach", "2025-12-01T00:00:00.000", "l1c", "2.0.0", "all", None),
+    # CSV file matching file_rules for REACH (l1c, "%Y%m%dT%H%M%S" format)
+    ("REACH-ALL_20251205T060517_20251205T060517.csv", "reach", "2025-12-05T06:05:17.000", "l1c", None, None, None),
+    # JSON file matching file_rules for REACH (l1c, "%Y%m%dT%H%M%S" format)
+    ("REACH-ALL_20251201T013010_20251205T060517.json", "reach", "2025-12-01T01:30:10.000", "l1c", None, None, None),
 ])
 def test_parse_swxsoc_pipeline_science_files(use_mission, filename, instrument, time, level, version, mode, descriptor):
     """Testing parsing of SWxSOC Pipeline (REACH) filenames."""

--- a/swxsoc/util/tests/test_util.py
+++ b/swxsoc/util/tests/test_util.py
@@ -225,9 +225,9 @@ def test_parse_padre_science_files(use_mission, filename, instrument, time, leve
     # Standard format CDF file with underscore in mission name
     ("swxsoc_pipeline_reach_all_l1c_20251201T000000_v2.0.0.cdf", "reach", "2025-12-01T00:00:00.000", "l1c", "2.0.0", "all", None),
     # CSV file matching file_rules for REACH (l1c, "%Y%m%dT%H%M%S" format)
-    ("REACH-ALL_20251205T060517_20251205T060517.csv", "reach", "2025-12-05T06:05:17.000", "l1c", None, None, None),
+    ("REACH-ALL_20251205T060517_20251205T060517.csv", "reach", "2025-12-05T06:05:17.000", "raw", None, None, None),
     # JSON file matching file_rules for REACH (l1c, "%Y%m%dT%H%M%S" format)
-    ("REACH-ALL_20251201T013010_20251205T060517.json", "reach", "2025-12-01T01:30:10.000", "l1c", None, None, None),
+    ("REACH-ALL_20251201T013010_20251205T060517.json", "reach", "2025-12-01T01:30:10.000", "raw", None, None, None),
 ])
 def test_parse_swxsoc_pipeline_science_files(use_mission, filename, instrument, time, level, version, mode, descriptor):
     """Testing parsing of SWxSOC Pipeline (REACH) filenames."""


### PR DESCRIPTION
- Updates for CSV and JSON files to be recognized as `raw` level. 
- Updates to support `L1C` CDF files. 

When sorting to S3:
- Raw files will go to `raw/YYYY/MM/DD/REACH-ALL_*.csv`
- CDF files will go to `'l1c/prelim/YYYY/MM/DD/reach_all_l1c_prelim_*_v1.0.0.cdf`