### PR TITLE
 Bug_63 Added custom filename as optional parameter

### DIFF
--- a/docs/user-guide/retrieving_data.rst
+++ b/docs/user-guide/retrieving_data.rst
@@ -47,11 +47,14 @@ To search for data based on multiple attributes such as instrument, level, and t
     # Search for data
     results = fido_client.search(query)
     print(results)
-    >>> instrument mode  test           time          level version ...   size       bucket                     etag                storage_class    last_modified   
-    >>>                                                            ...   byte                                                                                       
-    >>> ---------- ---- ----- ----------------------- ----- ------- ... ------- ---------------- ---------------------------------- ------------- -------------------
-    >>> meddea None False 2024-03-27T13:46:16.000    l0       1 ...  4648.0 dev-padre-meddea "8fca00048426ec8a114750a4de80c161"      STANDARD 2024-08-09 17:12:09
-    >>> meddea None  True 2024-03-27T13:46:16.000    l1   0.1.0 ... 25920.0 dev-padre-meddea "4b9c15fc55e8d05dd9b8414e146c51c3"      STANDARD 2024-08-09 17:12:24
+
+.. code-block:: text
+
+    instrument mode  test           time          level version ...   size       bucket                     etag                storage_class    last_modified   
+                                                               ...   byte                                                                                       
+    ---------- ---- ----- ----------------------- ----- ------- ... ------- ---------------- ---------------------------------- ------------- -------------------
+    meddea None False 2024-03-27T13:46:16.000    l0       1 ...  4648.0 dev-padre-meddea "8fca00048426ec8a114750a4de80c161"      STANDARD 2024-08-09 17:12:09
+    meddea None  True 2024-03-27T13:46:16.000    l1   0.1.0 ... 25920.0 dev-padre-meddea "4b9c15fc55e8d05dd9b8414e146c51c3"      STANDARD 2024-08-09 17:12:24
 
 Example 2: Search by a single Attribute
 ----------------------------------------
@@ -62,21 +65,24 @@ To search for data based on a single attribute such as instrument::
     from swxsoc.util.util import SWXSOCClient, AttrAnd, Instrument
 
     # Initialize the SWxSOC client
-    fido_client = util.SWXSOCClient()
+    fido_client = SWXSOCClient()
 
     # Test search with a query for specific instrument
     query = AttrAnd([Instrument("meddea")])
     results = fido_client.search(query)
     print(results)
-    >>> instrument mode  test           time          level version ...   size      bucket                   etag                storage_class    last_modified   
-    >>>                                                             ...   byte                                                                                    
-    >>> ---------- ---- ----- ----------------------- ----- ------- ... -------- ------------ ---------------------------------- ------------- -------------------
-    >>> meddea None False 2012-04-29T00:00:00.000    l0       1 ... 219672.0 padre-meddea "c1f165f22d8d4190323894a4df26cda4"      STANDARD 2024-07-10 18:17:34
-    >>> meddea None False 2023-04-30T00:00:00.000    l0       1 ... 219672.0 padre-meddea "c1f165f22d8d4190323894a4df26cda4"      STANDARD 2024-07-01 15:07:52
-    >>> meddea None False 2012-04-29T00:00:00.000    l1   0.0.1 ...      0.0 padre-meddea "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-10 18:17:58
-    >>> meddea None False 2023-04-30T00:00:00.000    l1   0.0.1 ...      0.0 padre-meddea "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-01 15:08:01
-    >>> meddea None False 2012-04-29T00:00:00.000    ql   0.0.1 ...      0.0 padre-meddea "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-10 18:18:01
-    >>> meddea None False 2023-04-30T00:00:00.000    ql   0.0.1 ...      0.0 padre-meddea "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-01 15:08:05
+
+.. code-block:: text
+
+    instrument mode  test           time          level version ...   size      bucket                   etag                storage_class    last_modified   
+                                                                ...   byte                                                                                    
+    ---------- ---- ----- ----------------------- ----- ------- ... -------- ------------ ---------------------------------- ------------- -------------------
+    meddea None False 2012-04-29T00:00:00.000    l0       1 ... 219672.0 padre-meddea "c1f165f22d8d4190323894a4df26cda4"      STANDARD 2024-07-10 18:17:34
+    meddea None False 2023-04-30T00:00:00.000    l0       1 ... 219672.0 padre-meddea "c1f165f22d8d4190323894a4df26cda4"      STANDARD 2024-07-01 15:07:52
+    meddea None False 2012-04-29T00:00:00.000    l1   0.0.1 ...      0.0 padre-meddea "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-10 18:17:58
+    meddea None False 2023-04-30T00:00:00.000    l1   0.0.1 ...      0.0 padre-meddea "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-01 15:08:01
+    meddea None False 2012-04-29T00:00:00.000    ql   0.0.1 ...      0.0 padre-meddea "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-10 18:18:01
+    meddea None False 2023-04-30T00:00:00.000    ql   0.0.1 ...      0.0 padre-meddea "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-01 15:08:05
 
 
 Example 3: Search all data
@@ -93,21 +99,24 @@ To search for all data::
     # Test search with a query for all data
     results = fido_client.search()
     print(results)
-    >>> instrument mode  test           time          level version ...   size      bucket                   etag                storage_class    last_modified   
-    >>>                                                             ...   byte                                                                                    
-    >>> ---------- ---- ----- ----------------------- ----- ------- ... -------- ------------ ---------------------------------- ------------- -------------------
-    >>> meddea None False 2012-04-29T00:00:00.000    l0       1 ... 219672.0 padre-meddea "c1f165f22d8d4190323894a4df26cda4"      STANDARD 2024-07-10 18:17:34
-    >>> meddea None False 2023-04-30T00:00:00.000    l0       1 ... 219672.0 padre-meddea "c1f165f22d8d4190323894a4df26cda4"      STANDARD 2024-07-01 15:07:52
-    >>> meddea None False 2012-04-29T00:00:00.000    l1   0.0.1 ...      0.0 padre-meddea "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-10 18:17:58
-    >>> meddea None False 2023-04-30T00:00:00.000    l1   0.0.1 ...      0.0 padre-meddea "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-01 15:08:01
-    >>> meddea None False 2012-04-29T00:00:00.000    ql   0.0.1 ...      0.0 padre-meddea "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-10 18:18:01
-    >>> meddea None False 2023-04-30T00:00:00.000    ql   0.0.1 ...      0.0 padre-meddea "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-01 15:08:05
-    >>> sharp  None False 2012-04-29T00:00:00.000    l0       1 ... 219672.0 padre-sharp  "c1f165f22d8d4190323894a4df26cda4"      STANDARD 2024-07-10 18:17:34
-    >>> sharp  None False 2023-04-30T00:00:00.000    l0       1 ... 219672.0 padre-sharp  "c1f165f22d8d4190323894a4df26cda4"      STANDARD 2024-07-01 15:07:52
-    >>> sharp  None False 2012-04-29T00:00:00.000    l1   0.0.1 ...      0.0 padre-sharp  "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-10 18:17:58
-    >>> sharp  None False 2023-04-30T00:00:00.000    l1   0.0.1 ...      0.0 padre-sharp  "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-01 15:08:01
-    >>> sharp  None False 2012-04-29T00:00:00.000    ql   0.0.1 ...      0.0 padre-sharp  "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-10 18:18:01
-    >>> sharp  None False 2023-04-30T00:00:00.000    ql   0.0.1 ...      0.0 padre-sharp  "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-01 15:08:05
+
+.. code-block:: text
+
+    instrument mode  test           time          level version ...   size      bucket                   etag                storage_class    last_modified   
+                                                                ...   byte                                                                                    
+    ---------- ---- ----- ----------------------- ----- ------- ... -------- ------------ ---------------------------------- ------------- -------------------
+    meddea None False 2012-04-29T00:00:00.000    l0       1 ... 219672.0 padre-meddea "c1f165f22d8d4190323894a4df26cda4"      STANDARD 2024-07-10 18:17:34
+    meddea None False 2023-04-30T00:00:00.000    l0       1 ... 219672.0 padre-meddea "c1f165f22d8d4190323894a4df26cda4"      STANDARD 2024-07-01 15:07:52
+    meddea None False 2012-04-29T00:00:00.000    l1   0.0.1 ...      0.0 padre-meddea "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-10 18:17:58
+    meddea None False 2023-04-30T00:00:00.000    l1   0.0.1 ...      0.0 padre-meddea "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-01 15:08:01
+    meddea None False 2012-04-29T00:00:00.000    ql   0.0.1 ...      0.0 padre-meddea "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-10 18:18:01
+    meddea None False 2023-04-30T00:00:00.000    ql   0.0.1 ...      0.0 padre-meddea "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-01 15:08:05
+    sharp  None False 2012-04-29T00:00:00.000    l0       1 ... 219672.0 padre-sharp  "c1f165f22d8d4190323894a4df26cda4"      STANDARD 2024-07-10 18:17:34
+    sharp  None False 2023-04-30T00:00:00.000    l0       1 ... 219672.0 padre-sharp  "c1f165f22d8d4190323894a4df26cda4"      STANDARD 2024-07-01 15:07:52
+    sharp  None False 2012-04-29T00:00:00.000    l1   0.0.1 ...      0.0 padre-sharp  "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-10 18:17:58
+    sharp  None False 2023-04-30T00:00:00.000    l1   0.0.1 ...      0.0 padre-sharp  "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-01 15:08:01
+    sharp  None False 2012-04-29T00:00:00.000    ql   0.0.1 ...      0.0 padre-sharp  "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-10 18:18:01
+    sharp  None False 2023-04-30T00:00:00.000    ql   0.0.1 ...      0.0 padre-sharp  "d41d8cd98f00b204e9800998ecf8427e"      STANDARD 2024-07-01 15:08:05
 
 Downloading Data
 ================
@@ -147,4 +156,7 @@ Below is an example demonstrating how to download data using the `~swxsoc.util.u
 
     # Start the download
     dl.download()
-    >>> Files Downloaded: 100% 2/2 [00:00<00:00,  2.59file/s]
+
+.. code-block:: text
+
+    Files Downloaded: 100% 2/2 [00:00<00:00,  2.59file/s]

--- a/swxsoc/swxdata.py
+++ b/swxsoc/swxdata.py
@@ -912,7 +912,7 @@ class SWXData:
         # Re-Derive Metadata
         self._derive_metadata()
 
-    def save(self, output_path: Path = None, overwrite: bool = False):
+    def save(self, output_path: Path = None, filename: str = None, overwrite: bool = False):
         """
         Save the data to a CDF file.
 
@@ -921,6 +921,9 @@ class SWXData:
         output_path : `pathlib.Path`, optional
             A fully specified path to the directory where the file is to be saved.
             If not provided, saves to the current directory.
+        filename : `str`, optional
+            Custom filename for the output file (including .cdf extension).
+            If not provided, uses the Logical_file_id from metadata.
         overwrite : `bool`
             If set, overwrites existing file of the same name.
         Returns
@@ -934,10 +937,13 @@ class SWXData:
         if not output_path:
             output_path = Path.cwd()
         if overwrite:
-            cdf_file_path = output_path / (self.meta["Logical_file_id"] + ".cdf")
+            if filename:
+                cdf_file_path = output_path / filename
+            else:
+                cdf_file_path = output_path / (self.meta["Logical_file_id"] + ".cdf")
             if cdf_file_path.exists():
                 cdf_file_path.unlink()
-        return handler.save_data(data=self, file_path=output_path)
+        return handler.save_data(data=self, file_path=output_path, filename=filename)
 
     @classmethod
     def load(cls, file_path: Path):

--- a/swxsoc/swxdata.py
+++ b/swxsoc/swxdata.py
@@ -912,18 +912,17 @@ class SWXData:
         # Re-Derive Metadata
         self._derive_metadata()
 
-    def save(self, output_path: Path = None, filename: str = None, overwrite: bool = False):
+    def save(self, output_path: Path = None, overwrite: bool = False):
         """
         Save the data to a CDF file.
 
         Parameters
         ----------
         output_path : `pathlib.Path`, optional
-            A fully specified path to the directory where the file is to be saved.
-            If not provided, saves to the current directory.
-        filename : `str`, optional
-            Custom filename for the output file (including .cdf extension).
-            If not provided, uses the Logical_file_id from metadata.
+            Path to save location. Can be:
+            - A directory: saves using Logical_file_id from metadata as filename
+            - A full file path (with .cdf extension): saves using that filename
+            If not provided, saves to the current directory with Logical_file_id.
         overwrite : `bool`
             If set, overwrites existing file of the same name.
         Returns
@@ -936,14 +935,31 @@ class SWXData:
         handler = CDFHandler()
         if not output_path:
             output_path = Path.cwd()
+        
+        output_path = Path(output_path)
+        
+        # Smart logic: detect if output_path is a directory or full file path
+        if output_path.is_dir():
+            # It's a directory - use logical_file_id for filename
+            file_path = output_path
+            filename = None
+        elif not output_path.suffix:
+            # No suffix - add .cdf and treat as filename
+            file_path = output_path.parent if output_path.parent != Path() else Path.cwd()
+            filename = output_path.name + '.cdf'
+        else:
+            # Has suffix - use as filename
+            file_path = output_path.parent if output_path.parent != Path() else Path.cwd()
+            filename = output_path.name
+        
         if overwrite:
             if filename:
-                cdf_file_path = output_path / filename
+                cdf_file_path = file_path / filename
             else:
-                cdf_file_path = output_path / (self.meta["Logical_file_id"] + ".cdf")
+                cdf_file_path = file_path / (self.meta["Logical_file_id"] + ".cdf")
             if cdf_file_path.exists():
                 cdf_file_path.unlink()
-        return handler.save_data(data=self, file_path=output_path, filename=filename)
+        return handler.save_data(data=self, file_path=file_path, filename=filename)
 
     @classmethod
     def load(cls, file_path: Path):

--- a/swxsoc/util/io.py
+++ b/swxsoc/util/io.py
@@ -331,7 +331,7 @@ class CDFHandler(SWXIOHandler):
             var_attrs["UNITS"] = u.dimensionless_unscaled.to_string()
             _load_data(spectra, var_name, var_data, var_attrs, time)
 
-    def save_data(self, data, file_path: Path):
+    def save_data(self, data, file_path: Path, filename: str = None):
         """
         Save heliophysics data to a CDF file.
 
@@ -341,6 +341,9 @@ class CDFHandler(SWXIOHandler):
             An instance of `SWXData` containing the data to be saved.
         file_path : `pathlib.Path`
             A fully specified path to the directory where the CDF file is to be saved.
+        filename : `str`, optional
+            Custom filename for the output file (including .cdf extension).
+            If not provided, uses the Logical_file_id from metadata.
 
         Returns
         -------
@@ -350,7 +353,10 @@ class CDFHandler(SWXIOHandler):
         from spacepy.pycdf import CDF
 
         # Initialize a new CDF
-        cdf_filename = f"{data.meta['Logical_file_id']}.cdf"
+        if filename:
+            cdf_filename = filename
+        else:
+            cdf_filename = f"{data.meta['Logical_file_id']}.cdf"
         output_cdf_filepath = str(Path(file_path) / cdf_filename)
         with CDF(output_cdf_filepath, masterpath="") as cdf_file:
             # Add Global Attriubtes to the CDF File

--- a/swxsoc/util/tests/test_io.py
+++ b/swxsoc/util/tests/test_io.py
@@ -7,6 +7,7 @@ import numpy as np
 from numpy.random import random
 import tempfile
 from astropy.timeseries import TimeSeries
+from astropy.table import Table
 from astropy.time import Time
 from astropy.units import Quantity
 from astropy.nddata import NDData
@@ -21,7 +22,7 @@ def save_cdf_for_examination(sw_data, filename=None):
     """Save a copy to current dir for examination with custom filename or logical id.
        No output path will put it in the current directory which is the point of this
        function."""
-    if False: # change to True if you'd like to use this feature
+    if True: # change to True if you'd like to use this feature
         if filename:
             # Add .cdf suffix if not already present
             if not filename.endswith('.cdf'):
@@ -188,6 +189,8 @@ def test_cdf_custom_filename():
     """
     # Get Test Data
     td = get_test_sw_data()
+    assert isinstance(td.timeseries, TimeSeries) 
+    assert isinstance(td.timeseries, Table)
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         tmp_path = Path(tmpdirname)
@@ -237,4 +240,40 @@ def test_cdf_custom_filename():
         )
         assert test_file_output_path_overwrite.name == another_custom_filename + ".cdf"
         assert test_file_output_path_overwrite.exists()
+        
+        # Test 6: Create actual FITS file for comparison with CDF
+        # This demonstrates that FITS and CDF are different formats
+        fits_filename = "real_fits_format.fits"
+        fits_path = tmp_path / fits_filename
+        
+        # Convert TimeSeries to Table and write as actual FITS format
+        fits_table = Table(td.timeseries)
+        fits_table.write(fits_path, format='fits', overwrite=True)
+        
+        # Verify FITS file was created
+        assert fits_path.exists()
+        
+        # Astropy can read it back as a Table
+        loaded_fits_table = Table.read(fits_path, format='fits')
+        assert len(loaded_fits_table) == len(td.timeseries)
+        
+        # But SWXData.load() cannot read FITS format (only CDF)
+        with pytest.raises(Exception):
+            SWXData.load(fits_path)  # Will fail - no FITS handler exists
+        
+        
+        # Test 7: CDF can store text data - demonstrate CDF is a rich format
+        # Add text as a global attribute
+        td.meta['Custom_text_description'] = "This is txt in a CDF file"
+        
+        # Save and reload
+        cdf_with_text_path = tmp_path / "cdf_with_text.cdf"
+        td.save(output_path=cdf_with_text_path, overwrite=True)
+        
+        # Load back and verify text is preserved
+        td_with_text = SWXData.load(cdf_with_text_path)
+        assert td_with_text.meta['Custom_text_description'] == "This is txt in a CDF file"
+        
+
+        
 

--- a/swxsoc/util/tests/test_io.py
+++ b/swxsoc/util/tests/test_io.py
@@ -10,6 +10,7 @@ from astropy.timeseries import TimeSeries
 from astropy.table import Table
 from astropy.time import Time
 from astropy.units import Quantity
+import astropy.units as u
 from astropy.nddata import NDData
 from astropy.wcs import WCS
 from ndcube import NDCube, NDCollection
@@ -263,12 +264,28 @@ def test_cdf_custom_filename():
         
         
         # Test 7: CDF can store text data - demonstrate CDF is a rich format
-        # Add text as a global attribute
-        td.meta['Custom_text_description'] = "This is txt in a CDF file"
+        # Create minimal SWXData with just text metadata (no arrays)
+        minimal_meta = {
+            "Descriptor": "EEA>Text Storage Test",
+            "Data_level": "l0>Level 0",
+            "Data_version": "v0.0.1",
+            "Custom_text_description": "This is txt in a CDF file"
+        }
+        
+        # Minimal TimeSeries with just one time point (required)
+        minimal_ts = TimeSeries(
+            time_start="2024-01-01T00:00:00",
+            time_delta=1*u.s,
+            data={"value": Quantity([1, 2], unit=u.dimensionless_unscaled, dtype=np.uint16)}
+        )
+        minimal_ts["value"].meta = {"CATDESC": "Minimal test value", "VAR_TYPE": "data"}
+        minimal_ts.meta = minimal_meta
+        
+        td_text = SWXData(timeseries=minimal_ts)
         
         # Save and reload
         cdf_with_text_path = tmp_path / "cdf_with_text.cdf"
-        td.save(output_path=cdf_with_text_path, overwrite=True)
+        td_text.save(output_path=cdf_with_text_path, overwrite=True)
         
         # Load back and verify text is preserved
         td_with_text = SWXData.load(cdf_with_text_path)

--- a/swxsoc/util/tests/test_io.py
+++ b/swxsoc/util/tests/test_io.py
@@ -162,3 +162,36 @@ def test_cdf_spectra_data():
         td_loaded = SWXData.load(test_file_output_path)
 
         assert "Test_Spectra_Var" in td_loaded.spectra
+
+
+def test_cdf_custom_filename():
+    """
+    Test that a custom filename can be provided instead of using Logical_file_id
+    """
+    # Get Test Data
+    td = get_test_sw_data()
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        tmp_path = Path(tmpdirname)
+        
+        # Save with custom filename
+        custom_filename = "my_custom_test_file.cdf"
+        test_file_output_path = td.save(output_path=tmp_path, filename=custom_filename)
+        
+        # Verify the file was created with the custom name
+        assert test_file_output_path.name == custom_filename
+        assert test_file_output_path.exists()
+        assert test_file_output_path.parent == tmp_path
+        
+        # Load the file back and verify it's correct
+        td_loaded = SWXData.load(test_file_output_path)
+        
+        assert len(td.timeseries) == len(td_loaded.timeseries)
+        assert len(td.timeseries.columns) == len(td_loaded.timeseries.columns)
+        
+        # Test that default behavior still works (no filename provided)
+        test_file_output_path_default = td.save(output_path=tmp_path, overwrite=True)
+        expected_default_name = f"{td.meta['Logical_file_id']}.cdf"
+        assert test_file_output_path_default.name == expected_default_name
+        assert test_file_output_path_default.exists()
+

--- a/swxsoc/util/tests/test_io.py
+++ b/swxsoc/util/tests/test_io.py
@@ -23,7 +23,7 @@ def save_cdf_for_examination(sw_data, filename=None):
     """Save a copy to current dir for examination with custom filename or logical id.
        No output path will put it in the current directory which is the point of this
        function."""
-    if True: # change to True if you'd like to use this feature
+    if False: # change to True if you'd like to use this feature
         if filename:
             # Add .cdf suffix if not already present
             if not filename.endswith('.cdf'):

--- a/swxsoc/util/tests/test_io.py
+++ b/swxsoc/util/tests/test_io.py
@@ -17,6 +17,13 @@ from swxsoc.swxdata import SWXData
 from swxsoc.util import const
 
 
+def save_for_examination(sw_data, filename):
+    """Save a copy to current dir for examination with custom filename."""
+    if False:
+       sw_data.meta["Logical_file_id"] = filename
+       sw_data.save(overwrite=True)
+
+
 def get_test_sw_data():
     """
     Function to get test swxsoc.swxdata.SWXData objects to re-use in other tests
@@ -88,6 +95,7 @@ def test_cdf_io():
     with tempfile.TemporaryDirectory() as tmpdirname:
         # Convert SWXData the to a CDF File
         test_file_output_path = td.save(output_path=tmpdirname)
+        save_for_examination(td, "io")
 
         # Load the CDF to a SWXData Object
         td_loaded = SWXData.load(test_file_output_path)
@@ -119,6 +127,7 @@ def test_cdf_nrv_support_data():
         tmp_path = Path(tmpdirname)
         # Convert HermesData the to a CDF File
         test_file_output_path = td.save(output_path=tmp_path)
+        save_for_examination(td, "nrv_support_data")
 
         # Load the JSON file as JSON
         with CDF(str(test_file_output_path), readonly=False) as cdf_file:
@@ -151,6 +160,7 @@ def test_cdf_spectra_data():
         tmp_path = Path(tmpdirname)
         # Convert HermesData the to a CDF File
         test_file_output_path = td.save(output_path=tmp_path)
+        save_for_examination(td, "spectra_data")
 
         # Load the JSON file as JSON
         with CDF(str(test_file_output_path), readonly=False) as cdf_file:
@@ -177,6 +187,7 @@ def test_cdf_custom_filename():
         # Save with custom filename
         custom_filename = "my_custom_test_file.cdf"
         test_file_output_path = td.save(output_path=tmp_path, filename=custom_filename)
+        save_for_examination(td, "custom_filename")
         
         # Verify the file was created with the custom name
         assert test_file_output_path.name == custom_filename
@@ -194,4 +205,13 @@ def test_cdf_custom_filename():
         expected_default_name = f"{td.meta['Logical_file_id']}.cdf"
         assert test_file_output_path_default.name == expected_default_name
         assert test_file_output_path_default.exists()
+        
+        # Test custom filename with overwrite (covers both parameters together)
+        another_custom_filename = "overwrite_test.cdf"
+        test_file_output_path_overwrite = td.save(
+            output_path=tmp_path, filename=another_custom_filename, overwrite=True
+        )
+        save_for_examination(td, "custom_filename_overwrite")
+        assert test_file_output_path_overwrite.name == another_custom_filename
+        assert test_file_output_path_overwrite.exists()
 

--- a/swxsoc/util/tests/test_io.py
+++ b/swxsoc/util/tests/test_io.py
@@ -263,34 +263,29 @@ def test_cdf_custom_filename():
             SWXData.load(fits_path)  # Will fail - no FITS handler exists
         
         
-        # Test 7: CDF can store text data - demonstrate CDF is a rich format
-        # Create minimal SWXData with just text metadata (no arrays)
-        minimal_meta = {
-            "Descriptor": "EEA>Text Storage Test",
+        # Test 7: Cannot create SWXData with empty TimeSeries (even with metadata)
+        # This demonstrates SWXData validation requires actual time points, not just metadata
+        
+        # Create a TimeSeries and then remove all rows to make it empty
+        ts_with_data = TimeSeries(
+            time_start="2024-01-01T00:00:00", 
+            time_delta=1*u.s, 
+            n_samples=2,
+            data={"value": [1, 2] * u.dimensionless_unscaled}
+        )
+        empty_ts = ts_with_data[:0]  # Slice to get empty TimeSeries (length 0)
+        
+        # Add metadata - but it won't help, still needs time points
+        empty_ts.meta = {
+            "Descriptor": "EEA>Empty Test Data",
             "Data_level": "l0>Level 0",
             "Data_version": "v0.0.1",
-            "Custom_text_description": "This is txt in a CDF file"
+            "Logical_file_id": "hermes_eea_l0_test_empty"
         }
-        
-        # Minimal TimeSeries with just one time point (required)
-        minimal_ts = TimeSeries(
-            time_start="2024-01-01T00:00:00",
-            time_delta=1*u.s,
-            data={"value": Quantity([1, 2], unit=u.dimensionless_unscaled, dtype=np.uint16)}
-        )
-        minimal_ts["value"].meta = {"CATDESC": "Minimal test value", "VAR_TYPE": "data"}
-        minimal_ts.meta = minimal_meta
-        
-        td_text = SWXData(timeseries=minimal_ts)
-        
-        # Save and reload
-        cdf_with_text_path = tmp_path / "cdf_with_text.cdf"
-        td_text.save(output_path=cdf_with_text_path, overwrite=True)
-        
-        # Load back and verify text is preserved
-        td_with_text = SWXData.load(cdf_with_text_path)
-        assert td_with_text.meta['Custom_text_description'] == "This is txt in a CDF file"
-        
-
+      
+        with pytest.raises(ValueError, match="timeseries cannot be empty"):
+            SWXData(timeseries=empty_ts)  # Will fail - metadata alone isn't enough
+         
+            
         
 

--- a/swxsoc/util/tests/test_io.py
+++ b/swxsoc/util/tests/test_io.py
@@ -17,11 +17,16 @@ from swxsoc.swxdata import SWXData
 from swxsoc.util import const
 
 
-def save_for_examination(sw_data, filename):
-    """Save a copy to current dir for examination with custom filename."""
-    if False:
-       sw_data.meta["Logical_file_id"] = filename
-       sw_data.save(overwrite=True)
+def save_cdf_for_examination(sw_data, filename=None):
+    """Save a copy to current dir for examination with custom filename or logical id.
+       No output path will put it in the current directory which is the point of this
+       function."""
+    if False: # change to True if you'd like to use this feature
+        if filename:
+            # Add .cdf suffix if not already present
+            if not filename.endswith('.cdf'):
+                filename = filename + '.cdf'
+        sw_data.save(output_path=filename, overwrite=True)
 
 
 def get_test_sw_data():
@@ -95,7 +100,7 @@ def test_cdf_io():
     with tempfile.TemporaryDirectory() as tmpdirname:
         # Convert SWXData the to a CDF File
         test_file_output_path = td.save(output_path=tmpdirname)
-        save_for_examination(td, "io")
+        save_cdf_for_examination(td, "io")
 
         # Load the CDF to a SWXData Object
         td_loaded = SWXData.load(test_file_output_path)
@@ -127,7 +132,7 @@ def test_cdf_nrv_support_data():
         tmp_path = Path(tmpdirname)
         # Convert HermesData the to a CDF File
         test_file_output_path = td.save(output_path=tmp_path)
-        save_for_examination(td, "nrv_support_data")
+        save_cdf_for_examination(td, "nrv_support_data")
 
         # Load the JSON file as JSON
         with CDF(str(test_file_output_path), readonly=False) as cdf_file:
@@ -160,7 +165,7 @@ def test_cdf_spectra_data():
         tmp_path = Path(tmpdirname)
         # Convert HermesData the to a CDF File
         test_file_output_path = td.save(output_path=tmp_path)
-        save_for_examination(td, "spectra_data")
+        save_cdf_for_examination(td, "spectra_data")
 
         # Load the JSON file as JSON
         with CDF(str(test_file_output_path), readonly=False) as cdf_file:
@@ -176,19 +181,32 @@ def test_cdf_spectra_data():
 
 def test_cdf_custom_filename():
     """
-    Test that a custom filename can be provided instead of using Logical_file_id
+    Test that a custom filename can be provided instead of using Logical_file_id.
+    Tests the smart path logic where output_path can be either:
+    - A directory (uses Logical_file_id)
+    - A full file path (uses that filename)
     """
     # Get Test Data
     td = get_test_sw_data()
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         tmp_path = Path(tmpdirname)
+        expected_name = f"{td.meta['Logical_file_id']}.cdf"
         
-        # Save with custom filename
+        # Test 1: Save with directory path only (uses Logical_file_id)
+        
+        test_file_output_path = td.save(output_path=tmp_path)
+        save_cdf_for_examination(td)
+        
+        # Verify the file was created with Logical_file_id
+        assert test_file_output_path.exists()
+        assert test_file_output_path.name == expected_name
+        assert test_file_output_path.parent == tmp_path
+
+        # Test 2: Save with full file path (custom filename)
         custom_filename = "my_custom_test_file.cdf"
-        test_file_output_path = td.save(output_path=tmp_path, filename=custom_filename)
-        save_for_examination(td, "custom_filename")
-        
+        test_file_output_path = td.save(output_path=tmp_path / custom_filename)
+        save_cdf_for_examination(td, custom_filename)
         # Verify the file was created with the custom name
         assert test_file_output_path.name == custom_filename
         assert test_file_output_path.exists()
@@ -200,18 +218,23 @@ def test_cdf_custom_filename():
         assert len(td.timeseries) == len(td_loaded.timeseries)
         assert len(td.timeseries.columns) == len(td_loaded.timeseries.columns)
         
-        # Test that default behavior still works (no filename provided)
+        # Test 3: Overwrite with directory path
         test_file_output_path_default = td.save(output_path=tmp_path, overwrite=True)
-        expected_default_name = f"{td.meta['Logical_file_id']}.cdf"
-        assert test_file_output_path_default.name == expected_default_name
+        assert test_file_output_path_default.name == expected_name
         assert test_file_output_path_default.exists()
         
-        # Test custom filename with overwrite (covers both parameters together)
-        another_custom_filename = "overwrite_test.cdf"
+        # Test 4: Save with no path (saves to current dir with Logical_file_id)
+        test_file_output_path_cwd = td.save(overwrite=True)
+        assert test_file_output_path_cwd.exists()
+        assert test_file_output_path_cwd.name == expected_name
+        # Clean up file in current directory
+        test_file_output_path_cwd.unlink()
+        
+        # Test 5: Custom filename with overwrite (covers both parameters together)
+        another_custom_filename = "overwrite_test"
         test_file_output_path_overwrite = td.save(
-            output_path=tmp_path, filename=another_custom_filename, overwrite=True
+            output_path=tmp_path / another_custom_filename, overwrite=True
         )
-        save_for_examination(td, "custom_filename_overwrite")
-        assert test_file_output_path_overwrite.name == another_custom_filename
+        assert test_file_output_path_overwrite.name == another_custom_filename + ".cdf"
         assert test_file_output_path_overwrite.exists()
 


### PR DESCRIPTION
This is fairly simple as Steven said.
I've finished Bug_60 but will wait till meeting to push.

## Add Optional Custom Filename Parameter to CDF Save Functionality

### Summary
Adds an optional `filename` parameter to `SWXData.save()` allowing users to specify custom filenames when saving CDF files, rather than always using the `Logical_file_id` from metadata.

### Changes
- **swxdata.py**: Added `filename` parameter to `save()` method
- **io.py**: Updated `CDFHandler.save_data()` to accept and use custom filename
- **test_io.py**: Added `test_cdf_custom_filename()` to verify functionality

### Motivation
Previously, CDF filenames were always derived from the `Logical_file_id` metadata attribute. This enhancement provides flexibility for:
- Testing with descriptive filenames
- Creating temporary files with custom names
- Saving multiple versions without modifying metadata

# Custom filename
```py
sw_data.save(output_path=Path("./output"), filename="my_test.cdf")
# -> output/my_test.cdf
```

### Testing
- ✅ Custom filename saves correctly
- ✅ Default behavior (without filename parameter) unchanged
- ✅ Round-trip load/save works with custom filenames
- ✅ Overwrite flag works with both default and custom filenames

### Backward Compatibility
Fully backward compatible - the `filename` parameter is optional and defaults to the existing behavior.

---

Closes #63

