### PR TITLE
Add User Guide Docs for multi-epoch CDF files and variable naming

### DIFF
--- a/docs/user-guide/cdf_format_guide.rst
+++ b/docs/user-guide/cdf_format_guide.rst
@@ -594,3 +594,147 @@ The rules above are deterministic, but a few combinations surprise users.
   length, not the 4-byte-per-character NumPy storage width.
 
 See :doc:`fillval_and_masks` for the ``FILLVAL`` sentinel associated with each CDF type and how masked / ``NaN`` values are converted on write and read.
+
+====================================================
+6. Multi-Epoch CDF Files and Variable Naming
+====================================================
+
+When a :py:class:`~swxsoc.swxdata.SWXData` object contains multiple `~astropy.timeseries.TimeSeries` (multi-epoch data), each with its own time variable, special considerations apply for CDF file creation.
+CDF files use a flat namespace where all variable names must be globally unique, while Python uses a hierarchical structure.
+This section describes how ``swxsoc`` handles this translation automatically.
+
+--------------------------------------
+6.1 Problem: Flat vs. Hierarchical
+--------------------------------------
+
+In Python, you might organize data hierarchically::
+
+    timeseries["REACH-165"]["Lat"]
+    timeseries["REACH-165"]["Lon"]
+    timeseries["REACH-134"]["Lat"]
+    timeseries["REACH-134"]["Lon"]
+
+However, CDF files require a flat namespace where all variables are at the same level.
+Without proper handling, variables from different epochs with identical names (``Lat``, ``Lon``) would overwrite each other, resulting in data loss.
+
+--------------------------------------
+6.2 Solution: Automatic Prefixing
+--------------------------------------
+
+To prevent naming conflicts, ``swxsoc`` automatically prefixes all variable names with their sanitized epoch key when writing multi-epoch data to CDF files.
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+6.2.1 Write Operation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+During CDF file creation, variable names are automatically prefixed::
+
+    timeseries["REACH-165"]["Lat"]       → CDF variable "REACH_165_Lat"
+    timeseries["REACH-165"]["time"]      → CDF variable "REACH_165_Epoch"
+    timeseries["REACH-134"]["Lat"]       → CDF variable "REACH_134_Lat"
+    timeseries["REACH-134"]["time"]      → CDF variable "REACH_134_Epoch"
+
+**Special Cases:**
+
+* The default epoch (typically ``"Epoch"``) remains unprefixed for backward compatibility with existing CDF files and ISTP conventions.
+* Hyphens in epoch keys are replaced with underscores to comply with CDF naming requirements.
+* The time column (``"time"``) in each :py:class:`~astropy.timeseries.TimeSeries` is renamed to ``"<prefix>_Epoch"`` or just ``"Epoch"`` for the default case.
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+6.2.2 Read Operation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When loading a CDF file, ``swxsoc`` automatically detects prefixed variables and reconstructs the original hierarchical structure::
+
+    CDF variable "REACH_165_Lat"    → timeseries["REACH-165"]["Lat"]
+    CDF variable "REACH_165_Epoch"  → timeseries["REACH-165"]["time"]
+
+This ensures round-trip consistency: data saved to CDF and then loaded back maintains its original structure.
+
+--------------------------------------
+6.3 DEPEND_0 Attribute and ISTP
+--------------------------------------
+
+The ``DEPEND_0`` attribute is an **ISTP (International Solar-Terrestrial Physics) requirement** that links each time-varying variable to its corresponding time (epoch) variable.
+This is critical for multi-epoch CDF files where different variables may depend on different time axes.
+
+When writing multi-epoch data, ``swxsoc`` automatically:
+
+1. Sets ``DEPEND_0`` for each data variable to point to its corresponding epoch variable
+2. Uses the prefixed epoch name (e.g., ``"REACH_165_Epoch"``) for non-default epochs
+3. Uses ``"Epoch"`` for the default epoch key
+
+**Example CDF Structure:**
+
+For data with two satellites::
+
+    Variables:
+    - REACH_165_Epoch [5 records]
+    - REACH_165_Lat [5 records, DEPEND_0="REACH_165_Epoch"]
+    - REACH_165_Lon [5 records, DEPEND_0="REACH_165_Epoch"]
+    - REACH_134_Epoch [5 records]
+    - REACH_134_Lat [5 records, DEPEND_0="REACH_134_Epoch"]
+    - REACH_134_Lon [5 records, DEPEND_0="REACH_134_Epoch"]
+
+This structure clearly indicates which time axis each measurement depends on, enabling proper interpretation by analysis tools and adherence to ISTP guidelines.
+
+For more information about ISTP requirements, see the `ISTP Guidelines <http://spdf.gsfc.nasa.gov/istp_guide/istp_guide.html>`_.
+
+--------------------------------------
+6.4 Design Rationale
+--------------------------------------
+
+The automatic prefixing approach was chosen for several reasons:
+
+**Simplicity:**
+    No need to detect duplicate names or implement conditional logic; all non-default epoch variables are consistently prefixed.
+
+**Predictability:**
+    Users can reliably predict CDF variable names from their Python structure.
+
+**Robustness:**
+    Eliminates an entire class of bugs related to variable name collisions.
+
+**ISTP Compliance:**
+    Maintains compatibility with ISTP standards while supporting complex multi-epoch datasets.
+
+--------------------------------------
+6.5 Example: Multi-Satellite Scenario
+--------------------------------------
+
+Consider a constellation mission with 32 satellites, each collecting the same measurements (Latitude, Longitude, Position, Sensor A, Sensor B, etc.) at the same cadence.
+
+Without auto-prefixing, all 32 satellites' data would collapse into a single set of variables, losing 31 satellites' worth of data.
+
+With auto-prefixing, each satellite's data is preserved::
+
+    from astropy.time import Time, TimeDelta
+    from astropy.timeseries import TimeSeries
+    import astropy.units as u
+    import numpy as np
+    from swxsoc.swxdata import SWXData
+
+    # Create TimeSeries for multiple satellites
+    timeseries_dict = {}
+    for sat_id in range(165, 197):  # REACH-165 through REACH-196
+        times = Time('2024-01-01T00:00:00', scale='utc') + TimeDelta(np.arange(5) * u.s)
+        ts = TimeSeries(
+            time=times,
+            data={
+                'Lat': u.Quantity(np.random.uniform(-90, 90, 5), 'deg', dtype=np.float32),
+                'Lon': u.Quantity(np.random.uniform(-180, 180, 5), 'deg', dtype=np.float32),
+                'Sensor_A': u.Quantity(np.random.random(5), 'nT', dtype=np.float32),
+            }
+        )
+        timeseries_dict[f'REACH-{sat_id}'] = ts
+
+    # Create SWXData and save
+    meta = SWXData.global_attribute_template("reach", "l1", "1.0.0")
+    swx_data = SWXData(timeseries=timeseries_dict, meta=meta)
+    cdf_path = swx_data.save()  # Auto-prefixes all variables
+
+    # Load back - structure is preserved
+    loaded_data = SWXData.load(cdf_path)
+    # Each satellite's data is correctly restored to its epoch key
+
+This automatic handling allows missions with complex multi-epoch requirements to work seamlessly with CDF files while maintaining ISTP compliance and data integrity.

--- a/docs/user-guide/cdf_format_guide.rst
+++ b/docs/user-guide/cdf_format_guide.rst
@@ -609,35 +609,39 @@ This section describes how ``swxsoc`` handles this translation automatically.
 
 In Python, you might organize data hierarchically::
 
-    timeseries["REACH-165"]["Lat"]
-    timeseries["REACH-165"]["Lon"]
-    timeseries["REACH-134"]["Lat"]
-    timeseries["REACH-134"]["Lon"]
+  timeseries["REACH_165"]["Lat"]
+  timeseries["REACH_165"]["Lon"]
+  timeseries["REACH_134"]["Lat"]
+  timeseries["REACH_134"]["Lon"]
 
 However, CDF files require a flat namespace where all variables are at the same level.
 Without proper handling, variables from different epochs with identical names (``Lat``, ``Lon``) would overwrite each other, resulting in data loss.
 
 --------------------------------------
-6.2 Solution: Automatic Prefixing
+6.2 Solution: Selective Prefixing
 --------------------------------------
 
-To prevent naming conflicts, ``swxsoc`` automatically prefixes all variable names with their sanitized epoch key when writing multi-epoch data to CDF files.
+To prevent naming conflicts, ``swxsoc`` uses selective prefixing when writing multi-epoch data to CDF files.
+Only colliding variable names are deconflicted with an epoch-key prefix, and the first occurrence is kept unprefixed.
+For multi-timeseries data, dictionary keys must already be CDF-compatible (for example ``REACH_165``), rather than relying on automatic hyphen conversion.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 6.2.1 Write Operation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-During CDF file creation, variable names are automatically prefixed::
+During CDF file creation, conflicting names are handled asymmetrically::
 
-    timeseries["REACH-165"]["Lat"]       → CDF variable "REACH_165_Lat"
-    timeseries["REACH-165"]["time"]      → CDF variable "REACH_165_Epoch"
-    timeseries["REACH-134"]["Lat"]       → CDF variable "REACH_134_Lat"
-    timeseries["REACH-134"]["time"]      → CDF variable "REACH_134_Epoch"
+  timeseries["REACH_165"]["Lat"]       → CDF variable "Lat" (first conflicting occurrence)
+  timeseries["REACH_134"]["Lat"]       → CDF variable "REACH_134_Lat" (later conflicting occurrence)
+  timeseries["REACH_165"]["Sensor_A"]  → CDF variable "Sensor_A" (unique, no prefix)
+  timeseries["REACH_134"]["Sensor_B"]  → CDF variable "Sensor_B" (unique, no prefix)
+  timeseries["REACH_165"]["time"]      → CDF variable "Epoch" (default timeseries)
+  timeseries["REACH_134"]["time"]      → CDF variable "REACH_134_Epoch" (non-default timeseries)
 
 **Special Cases:**
 
 * The default epoch (typically ``"Epoch"``) remains unprefixed for backward compatibility with existing CDF files and ISTP conventions.
-* Hyphens in epoch keys are replaced with underscores to comply with CDF naming requirements.
+* Multi-timeseries dict keys should be underscore-safe and CDF-compatible before writing (for example ``REACH_134`` instead of ``REACH-134``).
 * The time column (``"time"``) in each :py:class:`~astropy.timeseries.TimeSeries` is renamed to ``"<prefix>_Epoch"`` or just ``"Epoch"`` for the default case.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -646,8 +650,10 @@ During CDF file creation, variable names are automatically prefixed::
 
 When loading a CDF file, ``swxsoc`` automatically detects prefixed variables and reconstructs the original hierarchical structure::
 
-    CDF variable "REACH_165_Lat"    → timeseries["REACH-165"]["Lat"]
-    CDF variable "REACH_165_Epoch"  → timeseries["REACH-165"]["time"]
+  CDF variable "Lat"              → timeseries["REACH_165"]["Lat"]
+  CDF variable "REACH_134_Lat"    → timeseries["REACH_134"]["Lat"]
+  CDF variable "Epoch"            → timeseries["REACH_165"]["time"]
+  CDF variable "REACH_134_Epoch"  → timeseries["REACH_134"]["time"]
 
 This ensures round-trip consistency: data saved to CDF and then loaded back maintains its original structure.
 
@@ -669,12 +675,14 @@ When writing multi-epoch data, ``swxsoc`` automatically:
 For data with two satellites::
 
     Variables:
-    - REACH_165_Epoch [5 records]
-    - REACH_165_Lat [5 records, DEPEND_0="REACH_165_Epoch"]
-    - REACH_165_Lon [5 records, DEPEND_0="REACH_165_Epoch"]
+    - Epoch [5 records] (default timeseries: REACH_165)
+    - Lat [5 records, DEPEND_0="Epoch"]
+    - Lon [5 records, DEPEND_0="Epoch"]
+    - Sensor_A [5 records, DEPEND_0="Epoch"]
     - REACH_134_Epoch [5 records]
     - REACH_134_Lat [5 records, DEPEND_0="REACH_134_Epoch"]
     - REACH_134_Lon [5 records, DEPEND_0="REACH_134_Epoch"]
+    - Sensor_B [5 records, DEPEND_0="REACH_134_Epoch"]
 
 This structure clearly indicates which time axis each measurement depends on, enabling proper interpretation by analysis tools and adherence to ISTP guidelines.
 
@@ -684,13 +692,13 @@ For more information about ISTP requirements, see the `ISTP Guidelines <http://s
 6.4 Design Rationale
 --------------------------------------
 
-The automatic prefixing approach was chosen for several reasons:
+The selective prefixing approach was chosen for several reasons:
 
 **Simplicity:**
-    No need to detect duplicate names or implement conditional logic; all non-default epoch variables are consistently prefixed.
+    Deconfliction is automatic, so users can work with natural per-timeseries names without manual renaming.
 
 **Predictability:**
-    Users can reliably predict CDF variable names from their Python structure.
+    Naming is deterministic: unique variables stay unchanged, and only later conflicting occurrences are prefixed.
 
 **Robustness:**
     Eliminates an entire class of bugs related to variable name collisions.
@@ -706,7 +714,7 @@ Consider a constellation mission with 32 satellites, each collecting the same me
 
 Without auto-prefixing, all 32 satellites' data would collapse into a single set of variables, losing 31 satellites' worth of data.
 
-With auto-prefixing, each satellite's data is preserved::
+With selective prefixing, each satellite's data is preserved::
 
     from astropy.time import Time, TimeDelta
     from astropy.timeseries import TimeSeries
@@ -716,7 +724,7 @@ With auto-prefixing, each satellite's data is preserved::
 
     # Create TimeSeries for multiple satellites
     timeseries_dict = {}
-    for sat_id in range(165, 197):  # REACH-165 through REACH-196
+    for sat_id in range(165, 197):  # REACH_165 through REACH_196
         times = Time('2024-01-01T00:00:00', scale='utc') + TimeDelta(np.arange(5) * u.s)
         ts = TimeSeries(
             time=times,
@@ -726,12 +734,12 @@ With auto-prefixing, each satellite's data is preserved::
                 'Sensor_A': u.Quantity(np.random.random(5), 'nT', dtype=np.float32),
             }
         )
-        timeseries_dict[f'REACH-{sat_id}'] = ts
+        timeseries_dict[f'REACH_{sat_id}'] = ts
 
     # Create SWXData and save
-    meta = SWXData.global_attribute_template("reach", "l1", "1.0.0")
+    meta = SWXData.global_attribute_template("eea", "l1", "1.0.0")
     swx_data = SWXData(timeseries=timeseries_dict, meta=meta)
-    cdf_path = swx_data.save()  # Auto-prefixes all variables
+    cdf_path = swx_data.save()  # Prefixes only variables that would collide
 
     # Load back - structure is preserved
     loaded_data = SWXData.load(cdf_path)

--- a/docs/user-guide/reading_writing_data.rst
+++ b/docs/user-guide/reading_writing_data.rst
@@ -124,6 +124,13 @@ For collections that have multiple Epochs, you can create a dictionary of `~astr
 
 This allows  you to have multiple time series in one :py:class:`~swxsoc.swxdata.SWXData` object.
 
+.. note::
+
+   When multiple :py:class:`~astropy.timeseries.TimeSeries` objects have the same column names (e.g., multiple satellites each collecting ``Lat``, ``Lon``, ``Sensor_A``), ``swxsoc`` automatically prevents naming conflicts during CDF file creation.
+   Each variable is prefixed with its sanitized epoch key (e.g., ``REACH_165_Lat``, ``REACH_134_Lat``) to ensure all data is preserved in the flat CDF namespace.
+   When loading the CDF file, the original structure is automatically reconstructed.
+   For more details, see :ref:`cdf_format_guide` Section 6 on Multi-Epoch CDF Files.
+
 Creating a ``NDCollection`` for ``SWXData`` `spectra`
 --------------------------------------------------------------
 
@@ -542,6 +549,13 @@ This function returns the full :py:class:`~pathlib.Path` to the CDF file that wa
 From this you can validate and distribute your CDF file.
 
 Missing data, ``NaN``, masks, and FILLVAL on write/read are described in :doc:`fillval_and_masks`.
+
+.. note::
+
+   **Multi-Epoch Data:** When saving a :py:class:`~swxsoc.swxdata.SWXData` object containing multiple :py:class:`~astropy.timeseries.TimeSeries` (multi-epoch data), variable names are automatically prefixed to prevent naming conflicts in the CDF file's flat namespace.
+   For example, ``timeseries["REACH-165"]["Lat"]`` becomes the CDF variable ``REACH_165_Lat``.
+   This prefixing is transparent on read operations—the original structure is automatically restored when loading the file.
+   See :ref:`cdf_format_guide` Section 6 for complete details on multi-epoch CDF files and variable naming conventions.
 
 Validating a CDF File
 =====================

--- a/docs/user-guide/reading_writing_data.rst
+++ b/docs/user-guide/reading_writing_data.rst
@@ -136,11 +136,11 @@ This allows  you to have multiple time series in one :py:class:`~swxsoc.swxdata.
 
 .. note::
 
-   When multiple :py:class:`~astropy.timeseries.TimeSeries` objects have the same column names (e.g., multiple satellites each collecting ``Lat``, ``Lon``, ``Sensor_A``), ``swxsoc`` automatically prevents naming conflicts during CDF file creation.
+    When multiple :py:class:`~astropy.timeseries.TimeSeries` objects have the same column names (e.g., multiple satellites each collecting ``Lat``, ``Lon``, ``Sensor_A``), ``swxsoc`` automatically prevents naming conflicts during CDF file creation.
     Prefixing is applied only when a naming collision occurs in the flat CDF namespace.
     The first occurrence keeps its original variable name (for example, ``Lat``), and later conflicting variables are prefixed with their sanitized epoch key (for example, ``REACH_134_Lat``).
-   When loading the CDF file, the original structure is automatically reconstructed.
-   For more details, see :ref:`cdf_format_guide` Section 6 on Multi-Epoch CDF Files.
+    When loading the CDF file, the original structure is automatically reconstructed.
+    For more details, see :ref:`cdf_format_guide` Section 6 on Multi-Epoch CDF Files.
 
 Creating a ``NDCollection`` for ``SWXData`` `spectra`
 --------------------------------------------------------------
@@ -572,8 +572,8 @@ Missing data, ``NaN``, masks, and FILLVAL on write/read are described in :doc:`f
 
     **Multi-Epoch Data:** When saving a :py:class:`~swxsoc.swxdata.SWXData` object containing multiple :py:class:`~astropy.timeseries.TimeSeries` (multi-epoch data), ``swxsoc`` selectively prefixes names only when needed to prevent collisions in the CDF file's flat namespace.
     For example, if ``Lat`` appears in multiple timeseries, the first occurrence remains ``Lat`` and later occurrences are written as prefixed names such as ``REACH_134_Lat``.
-   This prefixing is transparent on read operations—the original structure is automatically restored when loading the file.
-   See :ref:`cdf_format_guide` Section 6 for complete details on multi-epoch CDF files and variable naming conventions.
+    This prefixing is transparent on read operations—the original structure is automatically restored when loading the file.
+    See :ref:`cdf_format_guide` Section 6 for complete details on multi-epoch CDF files and variable naming conventions.
 
 Validating a CDF File
 =====================

--- a/docs/user-guide/reading_writing_data.rst
+++ b/docs/user-guide/reading_writing_data.rst
@@ -127,7 +127,8 @@ This allows  you to have multiple time series in one :py:class:`~swxsoc.swxdata.
 .. note::
 
    When multiple :py:class:`~astropy.timeseries.TimeSeries` objects have the same column names (e.g., multiple satellites each collecting ``Lat``, ``Lon``, ``Sensor_A``), ``swxsoc`` automatically prevents naming conflicts during CDF file creation.
-   Each variable is prefixed with its sanitized epoch key (e.g., ``REACH_165_Lat``, ``REACH_134_Lat``) to ensure all data is preserved in the flat CDF namespace.
+    Prefixing is applied only when a naming collision occurs in the flat CDF namespace.
+    The first occurrence keeps its original variable name (for example, ``Lat``), and later conflicting variables are prefixed with their sanitized epoch key (for example, ``REACH_134_Lat``).
    When loading the CDF file, the original structure is automatically reconstructed.
    For more details, see :ref:`cdf_format_guide` Section 6 on Multi-Epoch CDF Files.
 
@@ -552,8 +553,8 @@ Missing data, ``NaN``, masks, and FILLVAL on write/read are described in :doc:`f
 
 .. note::
 
-   **Multi-Epoch Data:** When saving a :py:class:`~swxsoc.swxdata.SWXData` object containing multiple :py:class:`~astropy.timeseries.TimeSeries` (multi-epoch data), variable names are automatically prefixed to prevent naming conflicts in the CDF file's flat namespace.
-   For example, ``timeseries["REACH-165"]["Lat"]`` becomes the CDF variable ``REACH_165_Lat``.
+    **Multi-Epoch Data:** When saving a :py:class:`~swxsoc.swxdata.SWXData` object containing multiple :py:class:`~astropy.timeseries.TimeSeries` (multi-epoch data), ``swxsoc`` selectively prefixes names only when needed to prevent collisions in the CDF file's flat namespace.
+    For example, if ``Lat`` appears in multiple timeseries, the first occurrence remains ``Lat`` and later occurrences are written as prefixed names such as ``REACH_134_Lat``.
    This prefixing is transparent on read operations—the original structure is automatically restored when loading the file.
    See :ref:`cdf_format_guide` Section 6 for complete details on multi-epoch CDF files and variable naming conventions.
 


### PR DESCRIPTION
- **New Section 6 in cdf_format_guide.rst** documents how `SWXData` automatically handles naming conflicts when multiple `TimeSeries` objects share column names (e.g., multi-satellite constellations). Explains selective prefixing strategy, DEPEND_0 ISTP requirements, and round-trip consistency on read/write operations.

- **Added notes to reading_writing_data.rst** that cross-reference the new guide and clarify that variable prefixing is automatic and transparent to users, with prefixing applied only when collisions occur in the flat CDF namespace.

- **Includes practical example** (32-satellite constellation scenario) demonstrating how the feature prevents data loss while maintaining ISTP compliance and working seamlessly with the CDF file format.

closes #96 